### PR TITLE
Economy rebalance: debt-driven startup model, realistic budgets, tech…

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -878,7 +878,7 @@ function App() {
                 const count = residents.length;
                 const calcPct = (statKey) => {
                   const avg = residents.reduce((sum, r) => sum + (r.stats[statKey] || 10), 0) / count;
-                  return Math.round((avg - 10) * 10);
+                  return Math.round((avg - 10) * 3);
                 };
                 const stats = [
                   { key: 'sharingTolerance', label: 'Sharing' },
@@ -1846,7 +1846,7 @@ function App() {
               </div>
               {expandedPrimitives.nutrition && (
                 <div className="primitive-body">
-                  <div className="formula-display">supply = min(N,cap) × outputRate × levelMult × quality × (1 + skillMult × cookSkill)</div>
+                  <div className="formula-display">supply = min(N,cap) × outputRate × levelMult × quality × (1 + skillMult × cookSkill) × budgetMult</div>
                   <div className="coverage-stats">
                     <span>Supply: {gameState?.coverageData?.nutrition?.supply?.toFixed(1) || 0}</span>
                     <span>Demand: {gameState?.coverageData?.nutrition?.demand?.toFixed(1) || 0}</span>
@@ -1884,7 +1884,7 @@ function App() {
               </div>
               {expandedPrimitives.fun && (
                 <div className="primitive-body">
-                  <div className="formula-display">supply = min(N,cap) × outputRate × levelMult × quality × (1 + skillMult × avgSocioStamina)</div>
+                  <div className="formula-display">supply = min(N,cap) × outputRate × levelMult × quality × (1 + skillMult × avgSocioStamina) × policyMult × budgetMult</div>
                   <div className="coverage-stats">
                     <span>Supply: {gameState?.coverageData?.fun?.supply?.toFixed(1) || 0}</span>
                     <span>Demand: {gameState?.coverageData?.fun?.demand?.toFixed(1) || 0}</span>
@@ -1922,7 +1922,7 @@ function App() {
               </div>
               {expandedPrimitives.drive && (
                 <div className="primitive-body">
-                  <div className="formula-display">supply = min(N,cap) × outputRate × levelMult × quality × (1 + skillMult × workEthic)</div>
+                  <div className="formula-display">supply = min(N,cap) × outputRate × levelMult × quality × (1 + skillMult × workEthic) × budgetMult</div>
                   <div className="coverage-stats">
                     <span>Supply: {gameState?.coverageData?.drive?.supply?.toFixed(1) || 0}</span>
                     <span>Demand: {gameState?.coverageData?.drive?.demand?.toFixed(1) || 0}</span>
@@ -1961,8 +1961,8 @@ function App() {
               {expandedPrimitives.cleanliness && (
                 <div className="primitive-body">
                   <div className="formula-display">messIn = messPerResident × N × overcrowdingPenalty</div>
-                  <div className="formula-display">cleanOut = cleanBase × bathQuality × cleanMult × (1 + skillMult × tidiness)</div>
-                  <div className="formula-display">debt += (messIn - cleanOut) × 0.5 - budgetReduction</div>
+                  <div className="formula-display">cleanOut = cleanBase × bathQ × cleanMult × (1 + skillMult × tidiness) × budgetMult × techBoosts</div>
+                  <div className="formula-display">debt += (messIn - cleanOut) × 0.5</div>
                   <div className="primitive-controls">
                     <div className="config-field">
                       <label>messPerResident</label>
@@ -1995,7 +1995,7 @@ function App() {
               </div>
               {expandedPrimitives.maintenance && (
                 <div className="primitive-body">
-                  <div className="formula-display">accumulates: wearIn × penalty - repairOut</div>
+                  <div className="formula-display">accumulates: (wearIn × penalty - repairOut × budgetMult × techBoosts) × 0.5</div>
                   <div className="primitive-controls">
                     <div className="config-field">
                       <label>wearPerResident</label>
@@ -2044,27 +2044,39 @@ function App() {
               </div>
               {expandedPrimitives.fatigue && (
                 <div className="primitive-body">
-                  <div className="formula-display">accumulates: (exertion - recovery) / N</div>
+                  <div className="formula-display">exertion = exertBase × (1 + workMult × workEthic + socioMult × sociability) + funFatigueCoeff × funSupply/N + driveFatigueCoeff × driveSupply/N</div>
+                  <div className="formula-display">recovery = recoverBase × bedroomQ × recoveryMult × (1 + partyCoeff × partyStamina) × budgetMult × wellnessBoost</div>
+                  <div className="formula-display">accumulates: exertion - recovery</div>
                   <div className="primitive-controls">
                     <div className="config-field">
                       <label>exertBase</label>
-                      <input type="number" step="0.5" value={editConfig?.primitives?.fatigue?.exertBase ?? 3}
+                      <input type="number" step="0.01" value={editConfig?.primitives?.fatigue?.exertBase ?? 0.62}
                         onChange={(e) => updatePrimitiveConfig('fatigue', 'exertBase', parseFloat(e.target.value))} />
                     </div>
                     <div className="config-field">
                       <label>recoverBase</label>
-                      <input type="number" step="0.5" value={editConfig?.primitives?.fatigue?.recoverBase ?? 5}
+                      <input type="number" step="0.01" value={editConfig?.primitives?.fatigue?.recoverBase ?? 0.51}
                         onChange={(e) => updatePrimitiveConfig('fatigue', 'recoverBase', parseFloat(e.target.value))} />
                     </div>
                     <div className="config-field">
                       <label>workMult</label>
-                      <input type="number" step="0.1" value={editConfig?.primitives?.fatigue?.workMult ?? 0.3}
+                      <input type="number" step="0.01" value={editConfig?.primitives?.fatigue?.workMult ?? 0.25}
                         onChange={(e) => updatePrimitiveConfig('fatigue', 'workMult', parseFloat(e.target.value))} />
                     </div>
                     <div className="config-field">
                       <label>socioMult</label>
-                      <input type="number" step="0.1" value={editConfig?.primitives?.fatigue?.socioMult ?? 0.2}
+                      <input type="number" step="0.01" value={editConfig?.primitives?.fatigue?.socioMult ?? 0.25}
                         onChange={(e) => updatePrimitiveConfig('fatigue', 'socioMult', parseFloat(e.target.value))} />
+                    </div>
+                    <div className="config-field">
+                      <label>funFatigueCoeff</label>
+                      <input type="number" step="0.001" value={editConfig?.primitives?.fatigue?.funFatigueCoeff ?? 0.005}
+                        onChange={(e) => updatePrimitiveConfig('fatigue', 'funFatigueCoeff', parseFloat(e.target.value))} />
+                    </div>
+                    <div className="config-field">
+                      <label>driveFatigueCoeff</label>
+                      <input type="number" step="0.001" value={editConfig?.primitives?.fatigue?.driveFatigueCoeff ?? 0.005}
+                        onChange={(e) => updatePrimitiveConfig('fatigue', 'driveFatigueCoeff', parseFloat(e.target.value))} />
                     </div>
                   </div>
                   <div className="linked-buildings">
@@ -2080,28 +2092,53 @@ function App() {
           <div className="dev-tools-grid three-col">
             <div className="config-section">
               <h3>Budgets</h3>
-              <div style={{display: 'flex', justifyContent: 'flex-end', gap: '8px', marginBottom: '4px', fontSize: '0.7rem', color: '#a0aec0'}}>
-                <span style={{width: '70px', textAlign: 'center'}}>Start (£)</span>
-                <span style={{width: '70px', textAlign: 'center'}}>{'{eff/red}'}</span>
-              </div>
+              <div style={{fontSize: '0.7rem', color: '#a0aec0', marginBottom: '6px'}}>Starting £/week per category (+ £/capita neutral point)</div>
               {[
-                { key: 'nutrition', label: 'Ingredients', type: 'coverage' },
-                { key: 'cleanliness', label: 'Cleaning', type: 'outflow' },
-                { key: 'fun', label: 'Party supplies', type: 'coverage' },
-                { key: 'drive', label: 'Internet', type: 'coverage' },
-                { key: 'maintenance', label: 'Handiman', type: 'outflow' },
-                { key: 'fatigue', label: 'Wellness', type: 'outflow' }
+                { key: 'nutrition', label: 'Ingredients', def: 50, bpc: 15 },
+                { key: 'cleanliness', label: 'Cleaning supplies', def: 15, bpc: 5 },
+                { key: 'maintenance', label: 'Repairs & tools', def: 25, bpc: 8 },
+                { key: 'fatigue', label: 'Wellness', def: 15, bpc: 5 },
+                { key: 'fun', label: 'Entertainment', def: 30, bpc: 10 },
+                { key: 'drive', label: 'Internet & workspace', def: 15, bpc: 5 }
               ].map(item => (
-                <div key={item.key} className="config-field" style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}>
-                  <label style={{flex: 1}}>{item.label}</label>
-                  <input type="number" step="10" min="0" max="500" style={{width: '70px'}} value={editConfig.startingBudgets?.[item.key] ?? 0} onChange={(e) => {
+                <div key={item.key} className="config-field" style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '4px'}}>
+                  <label style={{flex: 1, fontSize: '0.7rem'}}>{item.label}</label>
+                  <input type="number" step="5" min="0" max="500" style={{width: '55px'}} value={editConfig.startingBudgets?.[item.key] ?? item.def} onChange={(e) => {
                     const val = Math.max(0, Math.min(500, parseInt(e.target.value) || 0));
                     setEditConfig(prev => ({
                       ...prev,
                       startingBudgets: { ...prev.startingBudgets, [item.key]: val }
                     }));
                   }} />
-                  <input type="number" step={item.type === 'coverage' ? '0.01' : '0.001'} style={{width: '70px', marginLeft: '8px'}} value={editConfig?.budgetConfig?.[item.key]?.[item.type === 'coverage' ? 'supplyPerPound' : 'outflowBoostPerPound'] ?? (item.type === 'coverage' ? 0.5 : 0.005)} onChange={(e) => updateBudgetConfig(item.key, item.type === 'coverage' ? 'supplyPerPound' : 'outflowBoostPerPound', parseFloat(e.target.value))} />
+                  <input type="number" step="1" min="1" max="50" style={{width: '40px', fontSize: '0.65rem', opacity: 0.7}} title="basePerCapita" value={editConfig?.budgetConfig?.[item.key]?.basePerCapita ?? item.bpc} onChange={(e) => {
+                    const val = Math.max(1, parseFloat(e.target.value) || 1);
+                    setEditConfig(prev => ({
+                      ...prev,
+                      budgetConfig: {
+                        ...prev.budgetConfig,
+                        [item.key]: { ...prev.budgetConfig?.[item.key], basePerCapita: val }
+                      }
+                    }));
+                  }} />
+                </div>
+              ))}
+              <div style={{fontSize: '0.7rem', color: '#a0aec0', marginTop: '8px', marginBottom: '4px'}}>Budget curve</div>
+              {[
+                { field: 'scaleExp', label: 'Scale exp', step: 0.05, def: 0.7 },
+                { field: 'floor', label: 'Floor (£0)', step: 0.05, def: 0.5 },
+                { field: 'ceiling', label: 'Ceiling', step: 0.05, def: 1.5 }
+              ].map(p => (
+                <div key={p.field} className="config-field" style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}>
+                  <label style={{flex: 1}}>{p.label}</label>
+                  <input type="number" step={p.step} style={{width: '70px'}} value={editConfig?.budgetConfig?.curve?.[p.field] ?? p.def} onChange={(e) => {
+                    setEditConfig(prev => ({
+                      ...prev,
+                      budgetConfig: {
+                        ...prev.budgetConfig,
+                        curve: { ...prev.budgetConfig?.curve, [p.field]: parseFloat(e.target.value) }
+                      }
+                    }));
+                  }} />
                 </div>
               ))}
             </div>
@@ -2485,9 +2522,9 @@ function App() {
                 <button 
                   className="action-button"
                   onClick={() => setBuildConfirm(building)}
-                  disabled={gameState.treasury < building.cost || (gameState.buildsThisWeek || 0) >= (gameState.config?.buildsPerWeek ?? 1)}
+                  disabled={gameState.treasury - building.cost < (gameState.config?.gameOverLimit ?? -5000) || (gameState.buildsThisWeek || 0) >= (gameState.config?.buildsPerWeek ?? 1)}
                 >
-                  {(gameState.buildsThisWeek || 0) >= (gameState.config?.buildsPerWeek ?? 1) ? 'Limit reached' : gameState.treasury < building.cost ? 'Not enough funds' : 'Build'}
+                  {(gameState.buildsThisWeek || 0) >= (gameState.config?.buildsPerWeek ?? 1) ? 'Limit reached' : gameState.treasury - building.cost < (gameState.config?.gameOverLimit ?? -5000) ? 'Debt limit' : 'Build'}
                 </button>
               </div>
             ))}
@@ -2728,15 +2765,15 @@ function App() {
                     availableTechs.map(tech => {
                       const cfg = gameState.techConfig?.[tech.id] || {};
                       const cost = cfg.cost || 500;
-                      const canAfford = gameState.treasury >= cost;
+                      const canAfford = gameState.treasury - cost >= (gameState.config?.gameOverLimit ?? -5000);
                       const isThisResearching = gameState.researchingTech === tech.id;
                       const typeLabel = tech.type === 'fixed_expense' ? 'Fixed Cost' : tech.type === 'building' ? 'Building' : tech.type === 'culture' ? 'Culture' : tech.type === 'upgrade' ? 'Upgrade' : 'Policy';
                       let effectText = '';
                       if (tech.type === 'fixed_expense') effectText = `+${cfg.effectPercent || 0}% boost, £${cfg.weeklyCost || 0}/wk`;
-                      else if (tech.type === 'policy') effectText = tech.id === 'chores_rota' ? 'Unlocks Cooking & Cleaning Rota' : tech.id === 'ocado' ? `+${cfg.effectPercent || 0}% ingredient efficiency` : tech.description;
+                      else if (tech.type === 'policy') effectText = tech.id === 'chores_rota' ? `+${cfg.effectPercent || 15}% cleanliness & maintenance + unlocks rotas` : tech.id === 'ocado' ? `+${cfg.effectPercent || 0}% ingredient efficiency` : tech.description;
                       else if (tech.type === 'building') effectText = tech.id === 'blanket_fort' ? 'Unlocks Heaven building' : tech.id === 'outdoor_plumbing' ? 'Unlocks Hot Tub building' : tech.description;
                       else if (tech.type === 'upgrade') effectText = 'Living Room upgrade (see Buildings)';
-                      else if (tech.type === 'culture') effectText = 'Unlocks next level technologies';
+                      else if (tech.type === 'culture') effectText = tech.id === 'wellness' ? `+${cfg.effectPercent || 20}% fatigue recovery` : 'Unlocks next level technologies';
                       
                       if (isThisResearching) return null;
                       

--- a/docs/Fort_Llama_Design_Principles_v0.51.md
+++ b/docs/Fort_Llama_Design_Principles_v0.51.md
@@ -162,13 +162,17 @@ Every player action flows through four layers before it affects outcomes. This p
 
 These model supply versus demand. Every resident creates demand; buildings, skills, and budgets create supply. The coverage score uses a logarithmic scale that makes the first unit of supply far more valuable than the last — getting from "Shortfall" to "Adequate" is easier than getting from "Good" to "Superb."
 
-**Design intent:** the baseline coverage state should be undersupplied. Without budget investment or favourable resident stats, coverage ratios should sit below 1.0, producing scores in the "Tight" range. This is the pressure that makes budget allocation a real decision — the player has to choose which coverage gap to close first, because they can't afford to close all of them. Reaching "Adequate" should require active investment; reaching "Good" should require stacking multipliers (tier bonuses, skill bonuses, policies, buildings).
+**Design intent:** the baseline coverage state should be undersupplied. Budget investment is required to maintain even basic supply — at £0 spend, supply is strangled to 50% of its potential (the `floor` parameter on the budget curve). The default starting budget of £10/category restores roughly old-baseline behaviour, but the player sees it costing money and is incentivised to optimise. Reaching "Adequate" requires meaningful budget investment; reaching "Good" requires stacking multipliers (tier bonuses, skill bonuses, policies, buildings) on top of that spend.
 
 #### Accumulator Primitives: Cleanliness, Maintenance, Fatigue
 
 These model debt that builds when inflow exceeds outflow and recovers when the balance reverses. They create memory: neglect has lasting consequences that can't be instantly fixed. Recovery is deliberately slower than accumulation — a week of neglect takes more than a week to undo.
 
-**Design intent:** accumulators should drift negative at baseline. Without investment, debt builds — visible pressure within a weekly cycle that motivates the player to act. Budgets amplify outflow (cleaning output, repair output, fatigue recovery), stacking with resident stats, tech upgrades, and building quality. A moderate budget should slow or halt the drift; stacking multipliers should reverse it. Fatigue specifically should create the intended work/party tension: high drive and high fun both contribute to fatigue, and the dynamic dampening system punishes whichever pillar the player is pushing hardest, pulling them back toward balance.
+**Design intent:** accumulators should drift negative at baseline. Without budget investment, outflow (cleaning, repair, recovery) runs at 50% effectiveness — debt builds rapidly, creating visible pressure that motivates the player to act. The budget funds the outflow process: cleaning supplies, maintenance materials, wellness programmes. Buildings and resident stats multiply whatever the budget provides. A moderate budget should slow or halt the drift; stacking multipliers (budget + tech) should reverse it.
+
+**Fatigue and activity**: Fatigue is unique among accumulators — it's driven not just by a fixed base rate but by what the commune is actually doing. Fun and drive supply both feed into fatigue exertion (`funFatigueCoeff × funSupply/N + driveFatigueCoeff × driveSupply/N`), so pushing harder on Partytime or Productivity directly increases fatigue pressure. This creates a natural cost to ambition: a player who invests heavily in fun and drive must also invest in fatigue recovery (wellness tech + fatigue budget) or face accumulating exhaustion. The dynamic dampening system in health metrics then punishes whichever pillar the player is pushing hardest, pulling them back toward balance. Together, activity fatigue and dynamic dampening create the "work hard OR party hard, but not both for free" tension that the three-pillar design requires.
+
+**Tech progression**: Early tech research is the primary tool for stabilising accumulators. Chores Rota (L1, £500) provides a 15% passive boost to both cleanliness and maintenance outflow — cheap and broadly useful. Cleaner (L2, £1000 + £150/wk fixed cost) adds a powerful 40% cleanliness boost. Wellness (L2, £1000) provides 20% fatigue recovery boost, specifically targeting the activity fatigue pressure. The tech tree creates a clear investment arc: stabilise accumulators early, then redirect budget toward coverage and growth.
 
 #### Instantaneous Primitives: Crowding, Noise
 
@@ -200,25 +204,53 @@ The economy is the pacing mechanism. Get it wrong and every other system breaks,
 
 ### The Starting Economy
 
-> **Target: Break-even requires effort; profitability requires growth.**
+> **Target: Start in debt. Recruit to survive. Profitability requires growth to ~75% capacity.**
 >
-> The starting economy should be tight — close to break-even but not comfortably so. The player needs enough headroom to make small budget investments (this is how they learn what budgets do), but should feel the pressure to grow. Profitability is earned, not given.
+> The player starts with 4 residents, zero treasury, and immediately begins losing money. Fixed costs (ground rent £700 + utilities £250 = £950/week) exceed income (4 × £150 rent = £600). The player must recruit aggressively to close the gap, reaching break-even around N=11 and profitability at N=12 (75% of 16-bed capacity).
 
-**The key constraint:** the player must be able to afford small budget experiments in the early weeks. If the economy is so punishing that any spending accelerates failure, the player has no way to learn the systems. A tight-but-not-negative cash flow gives the minimum breathing room for the early game to function as a tutorial — while still feeling perilous.
+**The Difficulty Squeeze:** Recruiting solves the economy but *worsens the accumulators*. More residents mean more mess, more wear, more fatigue — systems that were manageable at N=4 (cleanliness and maintenance stay at zero with a small group) begin accumulating relentlessly at N=8+. Tech progression is the escape valve: chores_rota and cleaner handle the accumulator pressure that growth creates. The player is always choosing between financial survival (recruit now) and operational stability (invest in tech first).
+
+**The debt model:** There is no starting treasury. The player goes into debt from day one, with game-over at -£5,000. At N=4 with frugal budgets, the burn rate is ~£570/week — giving roughly 9 weeks before bankruptcy. A player who recruits steadily (1/week) troughs around -£2,000 at week 5 and begins climbing out. A player who also invests in tech (£500–£1,000 lump sums) may trough at -£3,000 to -£4,000 — sailing close to the -£5,000 cliff but building the operational capacity to sustain a larger commune.
+
+**The key constraint:** vibes must stay high enough to attract recruits. If the player neglects quality of life to save money, vibes drop, recruitment stalls, and the debt spiral becomes inescapable. Budget investment keeps vibes healthy, which enables recruitment, which enables profitability. Cutting budgets to slow the burn actually accelerates failure.
 
 ### Growth Economics
 
-More residents means more income (rent) but also more demand on every system. Growth is initially the easiest path to profitability (fill the beds), but increasingly constrained as each new resident adds strain that requires capital investment to manage.
+More residents means more income (rent) but also more demand on every system. Growth is the only path to solvency — but each new resident adds accumulator pressure that budget alone cannot contain. The player must pair recruitment with tech investment to avoid trading financial collapse for operational collapse.
 
-Building costs are one-time but increase ongoing costs (ground rent and utilities multipliers). Research costs money now for benefits later. The player is always juggling short-term profitability against long-term capacity — and each population tier brings new bottlenecks that demand new multipliers to overcome.
+| Pop | Income @£150 | Neutral budget | Fixed £950 | Net/week |
+|-----|-------------|---------------|-----------|---------|
+| 4 (start) | £600 | £322 | £950 | **-£672** |
+| 8 | £1,200 | £523 | £950 | -£273 |
+| 12 (75%) | £1,800 | £694 | £950 | **+£156** |
+| 16 (100%) | £2,400 | £849 | £950 | **+£601** |
+
+Building costs are one-time but increase ongoing costs (ground rent and utilities multipliers). Research costs money now for benefits later — and in the debt model, every lump-sum investment pushes the player closer to the -£5,000 cliff. The player is always juggling short-term solvency against long-term capacity.
 
 ### Budget Effectiveness
 
-Budgets are the player's primary weekly tactical lever and the first multiplier mechanic they encounter. They must be impactful enough that the player feels the difference, but not so powerful that they trivialise the underlying pressure. Critically, budgets should exhibit clear diminishing returns: the first £50 allocated to a category should produce a noticeable improvement, the next £50 a smaller one, and so on. This is what makes budget allocation a genuine puzzle — spreading money across multiple categories should generally outperform dumping everything into one, and the player should feel that trade-off.
+Budgets are the player's primary weekly tactical lever and the first multiplier mechanic they encounter. Unlike the old additive model (where budgets topped up supply), **budget now funds base production**. Buildings provide capacity and processing efficiency; resident stats provide skill multipliers; but without budget, there's nothing to process. The kitchen can't cook without ingredients; bathrooms can't be cleaned without supplies.
 
-**For coverage primitives** (nutrition, fun, drive), budgets add directly to supply. Each pound of budget adds a fixed amount of supply (`supplyPerPound`). A moderate budget should visibly improve the coverage ratio — this is the immediate feedback that teaches the player how the system works. Diminishing returns come from the logarithmic scoring: the coverage score uses a log₂ curve, so doubling supply from 0.5 to 1.0 is worth 25 points, but doubling again from 1.0 to 2.0 is only worth another 25. The player is naturally nudged toward diversifying or seeking other multipliers (tech, policies, better residents) rather than brute-forcing a single gap.
+All six budget categories share a single **hyperbolic budget curve** with four key properties:
 
-**For accumulator primitives** (cleanliness, maintenance, fatigue), budgets amplify outflow — the cleaning, repair, or recovery process. Each pound of budget boosts the outflow multiplier (`outflowBoostPerPound`), which means budget effectiveness scales with the underlying outflow rate. A budget is more powerful when paired with good resident stats, tech upgrades, and quality buildings, because they all compound on the same term. A moderate budget should slow or halt the drift; stacking with other multipliers should reverse it. The compounding structure naturally creates diminishing returns: the jump from a 1.0× to 1.5× multiplier is more impactful than from 1.5× to 2.0×, because each increment applies to the same outflow base.
+1. **Zero-spend penalty.** At £0, effectiveness drops to `floor` (default 0.5 = 50%). Supply is strangled, outflow halved. The player can't ignore budgets.
+2. **Diminishing returns.** The curve is hyperbolic — the first £10 has far more impact than the next £10. Spreading budget across categories always outperforms dumping into one.
+3. **Population scaling.** The reference budget (`refBudget`) scales with population: more residents need more total spend. The formula is `refBudget = basePerCapita × N^scaleExp`. Each budget category has its own `basePerCapita` reflecting realistic per-llama weekly costs (e.g. Ingredients £44, Entertainment £26, Cleaning £10).
+4. **Economies of scale.** The `scaleExp` parameter (default 0.7) means per-capita cost *falls* as the commune grows. Communal bulk buying and shared infrastructure mean 12 llamas cost less per head than 4.
+
+The curve formula: `budgetMult = floor + (ceiling − floor) × budget / (budget + refBudget)`
+
+| Category | basePerCapita | Neutral @N=4 | Neutral @N=12 | Feel |
+|---|---|---|---|---|
+| Ingredients | £44 | £116 | £250 | £3/day/llama bulk cooking |
+| Cleaning supplies | £10 | £26 | £57 | Communal cleaning products |
+| Repairs & tools | £18 | £48 | £102 | Parts, tools, maintenance |
+| Wellness | £10 | £26 | £57 | Rest supplies, activities |
+| Entertainment | £26 | £69 | £148 | Games, outings, events |
+| Internet & workspace | £14 | £37 | £80 | Broadband, equipment |
+| **Total** | **£122** | **£322** | **£694** | |
+
+The budget multiplier applies uniformly to both coverage and accumulator primitives. For coverage, it multiplies base supply (so buildings and skills amplify the budget's effect). For accumulators, it multiplies outflow (so tidy residents and building quality make each cleaning £ go further). This creates the intended stacking design: budget is necessary but insufficient alone — the player must also invest in buildings, research, and recruit skilled residents.
 
 ---
 
@@ -230,9 +262,9 @@ The game's progression follows a repeating cycle: the baseline state creates pre
 
 ### The Early Game (Weeks 1–4)
 
-The player starts with a small commune, basic buildings, no tech, and a tight budget. The baseline state is hostile: accumulators are drifting negative, coverage is undersupplied, the economy squeezes. The goal of this phase is to learn the core systems by feeling the pressure and discovering that budgets and early decisions can address it.
+The player starts with 4 residents, basic buildings, no tech, and mounting debt. The commune itself is manageable — with only 4 llamas, cleanliness and maintenance accumulators stay near zero and the place feels like a "Showhome." But the books don't balance: £600 income vs £950+ costs means ~£570/week burn. The goal of this phase is to recruit urgently while maintaining vibes high enough to attract new residents.
 
-**Target experience:** Vibes at "Rough" to "Scrappy" (15–35). Coverage primitives are "Tight." Economy is close to break-even — tight enough to feel the pinch, loose enough for small budget experiments. Cleanliness and maintenance are visibly building but manageable with early investment. The player's first research completes by week 3–4, opening up the next wave of multipliers.
+**Target experience:** Vibes at "Scrappy" (25–30) — surprisingly decent for a small group. Coverage primitives are "Tight" but not collapsing. Fatigue is the only accumulator building (~7–9/week). The economy is clearly unsustainable — the player sees debt growing and feels the urgency to recruit. First tech research (chores_rota, £500) completes by week 3–4, preparing for the accumulator pressure that growth will bring.
 
 ### The Mid Game (Weeks 5–12)
 
@@ -256,10 +288,10 @@ These are the specific commitments that should guide every numerical tuning deci
 
 | Principle | Target |
 |-----------|--------|
-| **Economy** | Tight. Close to break-even at starting conditions; requires growth or smart budgeting to generate surplus. |
+| **Economy** | In debt from day one. ~£570/week burn at N=4. Break-even at N=11, profitable at N=12 (75% capacity). Game-over at -£5,000 (~9 weeks passive). |
 | **Coverage primitives** | Undersupplied at baseline (score ~35–45, "Tight"). Budget investment or good resident stats needed to reach "Adequate." |
 | **Accumulator drift** | Negative without investment. Visible pressure within a weekly cycle — enough to motivate action, not enough to collapse before the player can respond. |
-| **Fatigue** | Slightly positive net exertion so fatigue builds slowly, creating the work/party tension. |
+| **Fatigue** | Slightly positive net exertion plus activity fatigue from fun/drive. Builds meaningfully (~7/week without wellness tech). Wellness tech + budget stabilises it. |
 | **Churn** | 1–2 residents per week at starting conditions, not 3+. |
 | **Recruitment** | 1 slot base, with Partytime able to earn a second slot through moderate investment. |
 | **Vibes tier** | "Rough" to "Scrappy" (15–35), with a clear upward path for engaged players. |

--- a/server/config.js
+++ b/server/config.js
@@ -126,15 +126,46 @@ const DEFAULT_BUILDINGS = [
 ];
 
 const DEFAULT_TIER_CONFIG = {
-  brackets: [6, 12, 20, 50, 100],
-  outputMults: [1.0, 1.15, 1.3, 1.5, 1.75, 2.0],
-  healthMults: [1.0, 1.1, 1.2, 1.35, 1.5, 1.7],
-  qualityCaps: [2, 3, 4, 5, 5, 5]
+  "brackets": [
+    6,
+    12,
+    20,
+    50,
+    100
+  ],
+  "outputMults": [
+    1,
+    1.15,
+    1.3,
+    1.5,
+    1.75,
+    2
+  ],
+  "healthMults": [
+    1,
+    1.1,
+    1.2,
+    1.35,
+    1.5,
+    1.7
+  ],
+  "qualityCaps": [
+    2,
+    3,
+    4,
+    5,
+    5,
+    5
+  ]
 };
 
 const DEFAULT_POLICY_CONFIG = {
-  excludePercent: 0.25,
-  funPenalty: { threshold: 3, K: 0.15, P: 1.5 }
+  "excludePercent": 0.25,
+  "funPenalty": {
+    "threshold": 3,
+    "K": 0.15,
+    "P": 1.5
+  }
 };
 
 const POLICY_DEFINITIONS = [
@@ -192,156 +223,409 @@ const TECH_TREE = [
 ];
 
 const DEFAULT_TECH_CONFIG = {
-  chores_rota: { cost: 500 },
-  cleaner: { cost: 1000, weeklyCost: 150, effectPercent: 20 },
-  ocado: { cost: 1000, effectPercent: 15 },
-  wellness: { cost: 1000 },
-  great_hall: { cost: 1000 },
-  starlink: { cost: 500, weeklyCost: 100, effectPercent: 15 },
-  blanket_fort: { cost: 500 },
-  always_be_escalating: { cost: 1000 },
-  outdoor_plumbing: { cost: 1000 },
-  laundry_room: { cost: 2000 },
-  ukrainian_cleaner: { cost: 2000 },
-  competitive_cooking: { cost: 2000 },
-  majestic_guvnor: { cost: 2000 },
-  group_yoga: { cost: 2000 },
-  sauna: { cost: 2000 },
-  call_rooms: { cost: 2000 },
-  adderall: { cost: 2000, weeklyCost: 200, effectPercent: 25 },
-  party_planning: { cost: 2000 },
-  psychedelics: { cost: 2000, weeklyCost: 200, effectPercent: 20 },
-  polyamory: { cost: 2000 },
-  advanced_blanket_fort: { cost: 2000 }
+  "chores_rota": {
+    "cost": 500,
+    "effectPercent": 15
+  },
+  "cleaner": {
+    "cost": 1000,
+    "weeklyCost": 150,
+    "effectPercent": 40
+  },
+  "ocado": {
+    "cost": 1000,
+    "effectPercent": 15
+  },
+  "wellness": {
+    "cost": 1000,
+    "effectPercent": 20
+  },
+  "great_hall": {
+    "cost": 1000
+  },
+  "starlink": {
+    "cost": 500,
+    "weeklyCost": 100,
+    "effectPercent": 15
+  },
+  "blanket_fort": {
+    "cost": 500
+  },
+  "always_be_escalating": {
+    "cost": 1000
+  },
+  "outdoor_plumbing": {
+    "cost": 1000
+  },
+  "laundry_room": {
+    "cost": 2000
+  },
+  "ukrainian_cleaner": {
+    "cost": 2000
+  },
+  "competitive_cooking": {
+    "cost": 2000
+  },
+  "majestic_guvnor": {
+    "cost": 2000
+  },
+  "group_yoga": {
+    "cost": 2000
+  },
+  "sauna": {
+    "cost": 2000
+  },
+  "call_rooms": {
+    "cost": 2000
+  },
+  "adderall": {
+    "cost": 2000,
+    "weeklyCost": 200,
+    "effectPercent": 25
+  },
+  "party_planning": {
+    "cost": 2000
+  },
+  "psychedelics": {
+    "cost": 2000,
+    "weeklyCost": 200,
+    "effectPercent": 20
+  },
+  "polyamory": {
+    "cost": 2000
+  },
+  "advanced_blanket_fort": {
+    "cost": 2000
+  }
 };
 
 const DEFAULT_PRIMITIVE_CONFIG = {
-  penaltyK: 2,
-  penaltyP: 2,
-  penaltyOnset: 0.75,
-  recoveryDamping: 0.65,
-  crowding: { baseMult: 50, weight: 1.0, useCustomPenalty: false, penaltyK: 2, penaltyP: 2 },
-  noise: { baseSocial: 2.5, baseAmbient: 10, socioMult: 0.1, considMult: 0.3, useCustomPenalty: false, penaltyK: 2, penaltyP: 2 },
-  nutrition: { outputRate: 7, consumptionRate: 13, skillMult: 0.1, useCustomPenalty: false, penaltyK: 2, penaltyP: 2 },
-  cleanliness: { messPerResident: 0.10, cleanBase: 0.5, skillMult: 0.1, useCustomPenalty: false, penaltyK: 2, penaltyP: 2 },
-  maintenance: { wearPerResident: 0.08, repairBase: 0.5, handinessCoeff: 0.1, tidinessCoeff: 0.05, useCustomPenalty: true, penaltyK: 4, penaltyP: 3 },
-  fatigue: { exertBase: 0.5, recoverBase: 0.45, workMult: 0.3, socioMult: 0.2 },
-  fun: { outputRate: 9, consumptionRate: 16, skillMult: 0.1, considerationPenalty: 0.05, useCustomPenalty: false, penaltyK: 2, penaltyP: 2 },
-  drive: { outputRate: 6, slackRate: 11, skillMult: 0.1, useCustomPenalty: false, penaltyK: 2, penaltyP: 2 }
+  "penaltyK": 2,
+  "penaltyP": 2,
+  "penaltyOnset": 0.75,
+  "recoveryDamping": 0.65,
+  "crowding": {
+    "baseMult": 43,
+    "shareTolCoeff": 0.25,
+    "weight": 1,
+    "useCustomPenalty": false,
+    "penaltyK": 2,
+    "penaltyP": 2
+  },
+  "noise": {
+    "baseSocial": 2.25,
+    "baseAmbient": 10,
+    "socioMult": 0.25,
+    "considMult": 0.25,
+    "useCustomPenalty": false,
+    "penaltyK": 2,
+    "penaltyP": 2
+  },
+  "nutrition": {
+    "outputRate": 7.3,
+    "consumptionRate": 13,
+    "skillMult": 0.25,
+    "useCustomPenalty": false,
+    "penaltyK": 2,
+    "penaltyP": 2
+  },
+  "cleanliness": {
+    "messPerResident": 0.1,
+    "cleanBase": 0.52,
+    "skillMult": 0.25,
+    "useCustomPenalty": false,
+    "penaltyK": 2,
+    "penaltyP": 2
+  },
+  "maintenance": {
+    "wearPerResident": 0.08,
+    "repairBase": 0.54,
+    "handinessCoeff": 0.25,
+    "tidinessCoeff": 0.12,
+    "useCustomPenalty": true,
+    "penaltyK": 4,
+    "penaltyP": 3
+  },
+  "fatigue": {
+    "exertBase": 0.59,
+    "recoverBase": 0.51,
+    "workMult": 0.25,
+    "socioMult": 0.25,
+    "partyCoeff": 0.25,
+    "funFatigueCoeff": 0.005,
+    "driveFatigueCoeff": 0.005
+  },
+  "fun": {
+    "outputRate": 9.2,
+    "consumptionRate": 16,
+    "skillMult": 0.25,
+    "considerationPenalty": 0.12,
+    "useCustomPenalty": false,
+    "penaltyK": 2,
+    "penaltyP": 2
+  },
+  "drive": {
+    "outputRate": 6.3,
+    "slackRate": 11,
+    "skillMult": 0.25,
+    "useCustomPenalty": false,
+    "penaltyK": 2,
+    "penaltyP": 2
+  }
 };
 
 const DEFAULT_HEALTH_CONFIG = {
-  livingStandards: {
-    nutritionWeight: 0.5,
-    cleanlinessDampen: 0.35,
-    crowdingDampen: 0.35,
-    maintenanceDampen: 0.35,
-    rentCurve: 0.7,
-    rentTierCurvature: 2,
-    useCustomScaling: true,
-    ref0: 0.55,
-    alpha: 0.15,
-    p: 2,
-    tierMult: [1.0, 1.1, 1.2, 1.35, 1.5, 1.7]
+  "livingStandards": {
+    "nutritionWeight": 0.5,
+    "cleanlinessDampen": 0.35,
+    "crowdingDampen": 0.35,
+    "maintenanceDampen": 0.35,
+    "rentCurve": 0.7,
+    "rentTierCurvature": 2,
+    "useCustomScaling": true,
+    "ref0": 0.55,
+    "alpha": 0.15,
+    "p": 2,
+    "tierMult": [
+      1,
+      1.1,
+      1.2,
+      1.35,
+      1.5,
+      1.7
+    ]
   },
-  productivity: {
-    driveWeight: 1.0,
-    noiseWeight: 0.35,
-    crowdingWeight: 0.25,
-    useCustomScaling: false,
-    ref0: 0.3,
-    alpha: 0.15,
-    p: 2,
-    tierMult: [1.0, 1.1, 1.2, 1.35, 1.5, 1.7]
+  "productivity": {
+    "driveWeight": 1,
+    "noiseWeight": 0.35,
+    "crowdingWeight": 0.25,
+    "useCustomScaling": false,
+    "ref0": 0.3,
+    "alpha": 0.15,
+    "p": 2,
+    "tierMult": [
+      1,
+      1.1,
+      1.2,
+      1.35,
+      1.5,
+      1.7
+    ]
   },
-  partytime: {
-    funWeight: 1.0,
-    useCustomScaling: true,
-    ref0: 0.42,
-    alpha: 0.15,
-    p: 2,
-    tierMult: [1.0, 1.1, 1.2, 1.35, 1.5, 1.7]
+  "partytime": {
+    "funWeight": 1,
+    "useCustomScaling": true,
+    "ref0": 0.42,
+    "alpha": 0.15,
+    "p": 2,
+    "tierMult": [
+      1,
+      1.1,
+      1.2,
+      1.35,
+      1.5,
+      1.7
+    ]
   },
-  globalScaling: {
-    ref0: 0.35,
-    alpha: 0.15,
-    p: 2
+  "globalScaling": {
+    "ref0": 0.35,
+    "alpha": 0.15,
+    "p": 2
   },
-  pop0: 2,
-  tierBrackets: [6, 12, 20, 50, 100],
-  baseFatigueWeight: 0.5,
-  fatigueWeightSwing: 0.5,
-  churnBaselinePR: 35,
-  churnScalePerPoint: 0.01,
-  recruitBaselinePT: 35,
-  recruitScalePerSlot: 15,
-  baseRecruitSlots: 1
+  "pop0": 2,
+  "tierBrackets": [
+    6,
+    12,
+    20,
+    50,
+    100
+  ],
+  "baseFatigueWeight": 0.5,
+  "fatigueWeightSwing": 0.5,
+  "churnBaselinePR": 24,
+  "churnScalePerPoint": 0.01,
+  "recruitBaselinePT": 35,
+  "recruitScalePerSlot": 15,
+  "baseRecruitSlots": 1
 };
 
 const DEFAULT_VIBES_CONFIG = {
-  balancedThreshold: 0.18,
-  strongImbalanceThreshold: 0.30,
-  tierThresholds: [
-    { name: 'Shambles', min: 0, max: 0.15 },
-    { name: 'Rough', min: 0.15, max: 0.25 },
-    { name: 'Scrappy', min: 0.25, max: 0.35 },
-    { name: 'Fine', min: 0.35, max: 0.45 },
-    { name: 'Good', min: 0.45, max: 0.55 },
-    { name: 'Lovely', min: 0.55, max: 0.65 },
-    { name: 'Thriving', min: 0.65, max: 0.75 },
-    { name: 'Wonderful', min: 0.75, max: 0.85 },
-    { name: 'Glorious', min: 0.85, max: 0.95 },
-    { name: 'Utopia', min: 0.95, max: 1.01 }
+  "balancedThreshold": 0.18,
+  "strongImbalanceThreshold": 0.3,
+  "tierThresholds": [
+    {
+      "name": "Shambles",
+      "min": 0,
+      "max": 0.15
+    },
+    {
+      "name": "Rough",
+      "min": 0.15,
+      "max": 0.25
+    },
+    {
+      "name": "Scrappy",
+      "min": 0.25,
+      "max": 0.35
+    },
+    {
+      "name": "Fine",
+      "min": 0.35,
+      "max": 0.45
+    },
+    {
+      "name": "Good",
+      "min": 0.45,
+      "max": 0.55
+    },
+    {
+      "name": "Lovely",
+      "min": 0.55,
+      "max": 0.65
+    },
+    {
+      "name": "Thriving",
+      "min": 0.65,
+      "max": 0.75
+    },
+    {
+      "name": "Wonderful",
+      "min": 0.75,
+      "max": 0.85
+    },
+    {
+      "name": "Glorious",
+      "min": 0.85,
+      "max": 0.95
+    },
+    {
+      "name": "Utopia",
+      "min": 0.95,
+      "max": 1.01
+    }
   ],
-  scaleBreakpoints: [
-    { min: 1, max: 5, tierMin: 2, tierMax: 5 },
-    { min: 6, max: 10, tierMin: 2, tierMax: 6 },
-    { min: 11, max: 20, tierMin: 2, tierMax: 7 },
-    { min: 21, max: 35, tierMin: 1, tierMax: 8 },
-    { min: 36, max: 999, tierMin: 0, tierMax: 9 }
+  "scaleBreakpoints": [
+    {
+      "min": 1,
+      "max": 5,
+      "tierMin": 2,
+      "tierMax": 5
+    },
+    {
+      "min": 6,
+      "max": 10,
+      "tierMin": 2,
+      "tierMax": 6
+    },
+    {
+      "min": 11,
+      "max": 20,
+      "tierMin": 2,
+      "tierMax": 7
+    },
+    {
+      "min": 21,
+      "max": 35,
+      "tierMin": 1,
+      "tierMax": 8
+    },
+    {
+      "min": 36,
+      "max": 999,
+      "tierMin": 0,
+      "tierMax": 9
+    }
   ],
-  branchLabels: {
-    highPartytime: { mild: 'Party House', strong: 'Party Mansion' },
-    highProductivity: { mild: 'Grind House', strong: 'Sweat Shop' },
-    highLivingStandards: { mild: 'Showhome', strong: 'Dolls House' },
-    lowLivingStandards: { mild: 'Shanty Town', strong: 'Slum' },
-    lowProductivity: { mild: 'Decadent', strong: 'Chaotic' },
-    lowPartytime: { mild: 'Low Energy', strong: 'Dead' }
+  "branchLabels": {
+    "highPartytime": {
+      "mild": "Party House",
+      "strong": "Party Mansion"
+    },
+    "highProductivity": {
+      "mild": "Grind House",
+      "strong": "Sweat Shop"
+    },
+    "highLivingStandards": {
+      "mild": "Showhome",
+      "strong": "Dolls House"
+    },
+    "lowLivingStandards": {
+      "mild": "Shanty Town",
+      "strong": "Slum"
+    },
+    "lowProductivity": {
+      "mild": "Decadent",
+      "strong": "Chaotic"
+    },
+    "lowPartytime": {
+      "mild": "Low Energy",
+      "strong": "Dead"
+    }
   }
 };
 
 const DEFAULT_BUDGET_CONFIG = {
-  nutrition:   { key: 'nutrition',   label: 'Ingredients',        type: 'coverage', supplyPerPound: 0.5,         investment: 0 },
-  cleanliness: { key: 'cleanliness', label: 'Cleaning materials', type: 'outflow',  outflowBoostPerPound: 0.005, investment: 0 },
-  maintenance: { key: 'maintenance', label: 'Handiman',           type: 'outflow',  outflowBoostPerPound: 0.005, investment: 0 },
-  fatigue:     { key: 'fatigue',     label: 'Wellness',           type: 'outflow',  outflowBoostPerPound: 0.005, investment: 0 },
-  fun:         { key: 'fun',         label: 'Party supplies',     type: 'coverage', supplyPerPound: 0.5,         investment: 0 },
-  drive:       { key: 'drive',       label: 'Internet',           type: 'coverage', supplyPerPound: 0.5,         investment: 0 }
+  "curve": {
+    "basePerCapita": 2,
+    "scaleExp": 0.7,
+    "floor": 0.5,
+    "ceiling": 1.5
+  },
+  "nutrition": {
+    "key": "nutrition",
+    "label": "Ingredients",
+    "basePerCapita": 44
+  },
+  "cleanliness": {
+    "key": "cleanliness",
+    "label": "Cleaning supplies",
+    "basePerCapita": 10
+  },
+  "maintenance": {
+    "key": "maintenance",
+    "label": "Repairs & tools",
+    "basePerCapita": 18
+  },
+  "fatigue": {
+    "key": "fatigue",
+    "label": "Wellness",
+    "basePerCapita": 10
+  },
+  "fun": {
+    "key": "fun",
+    "label": "Entertainment",
+    "basePerCapita": 26
+  },
+  "drive": {
+    "key": "drive",
+    "label": "Internet & workspace",
+    "basePerCapita": 14
+  }
 };
 
 const INITIAL_DEFAULTS = {
   startingTreasury: 0,
-  startingResidents: 10,
+  startingResidents: 4,
   buildsPerWeek: 1,
   policyChangesPerWeek: 1,
   researchActionsPerWeek: 1,
   rentMin: 50,
   rentMax: 500,
-  defaultRent: 100,
-  groundRentBase: 800,
-  utilitiesBase: 200,
-  baseChurnRate: 0.20,
+  defaultRent: 150,
+  groundRentBase: 700,
+  utilitiesBase: 250,
+  baseChurnRate: 0.07,
   churnRentMultiplier: 0.0003,
-  gameOverLimit: -20000,
+  gameOverLimit: -5000,
   tickSpeed: 200,
   hoursPerTick: 4,
   startingBudgets: {
-    nutrition: 0,
-    cleanliness: 0,
-    maintenance: 0,
-    fatigue: 0,
-    fun: 0,
-    drive: 0
+    nutrition: 75,
+    cleanliness: 20,
+    maintenance: 30,
+    fatigue: 20,
+    fun: 45,
+    drive: 25
   },
   primitives: { ...DEFAULT_PRIMITIVE_CONFIG },
   health: { ...DEFAULT_HEALTH_CONFIG },

--- a/server/routes.js
+++ b/server/routes.js
@@ -301,8 +301,9 @@ router.post('/api/action/research', (req, res) => {
     return res.status(400).json({ error: 'Must research prerequisite first' });
   }
   const cost = state.techConfig[techId]?.cost || 500;
-  if (state.gameState.treasury < cost) {
-    return res.status(400).json({ error: 'Not enough funds' });
+  const debtLimit = state.gameConfig.gameOverLimit || -5000;
+  if (state.gameState.treasury - cost < debtLimit) {
+    return res.status(400).json({ error: `Would exceed debt limit (£${Math.abs(debtLimit)})` });
   }
 
   state.gameState.treasury -= cost;
@@ -573,8 +574,9 @@ function handleBuildAction(req, res) {
     return;
   }
 
-  if (state.gameState.treasury < building.cost) {
-    res.status(400).json({ error: 'Not enough funds' });
+  const buildDebtLimit = state.gameConfig.gameOverLimit || -5000;
+  if (state.gameState.treasury - building.cost < buildDebtLimit) {
+    res.status(400).json({ error: `Would exceed debt limit (£${Math.abs(buildDebtLimit)})` });
     return;
   }
 

--- a/server/utils.js
+++ b/server/utils.js
@@ -46,6 +46,20 @@ function getPrimitiveTierLabel(labelDef, score) {
   return labelDef.labels[labelDef.labels.length - 1];
 }
 
+/**
+ * Budget effectiveness curve — hyperbolic with population scaling.
+ *
+ *   budgetMult(0)   = floor            (neglect penalty, e.g. 0.25)
+ *   budgetMult(ref) ≈ midpoint         (neutral — old-baseline-equivalent)
+ *   budgetMult(∞)  → ceiling           (asymptotic cap, e.g. 1.5)
+ *
+ * refBudget = basePerCapita × N^scaleExp   (economies of scale)
+ */
+function budgetEffectiveness(budget, population, curveCfg) {
+  const ref = curveCfg.basePerCapita * Math.pow(Math.max(1, population), curveCfg.scaleExp);
+  return curveCfg.floor + (curveCfg.ceiling - curveCfg.floor) * budget / (budget + ref);
+}
+
 function dampener(value, weight) {
   const norm = value / 100;
   return Math.pow(1 - norm, weight);
@@ -62,6 +76,7 @@ module.exports = {
   log2CoverageScore,
   getCoverageTierLabel,
   getPrimitiveTierLabel,
+  budgetEffectiveness,
   dampener,
   baseline
 };


### PR DESCRIPTION
… wiring

Major economy restructure: players start with 4 residents, zero treasury, and go into debt immediately. Growth to 75% capacity (N=12) required for profitability. Game-over at -£5,000 creates genuine time pressure to recruit.

Key changes:
- Start N=4, £0 treasury, -£5,000 game-over (was N=10, £0, -£20,000)
- Rent £150/wk (was £100), ground rent £700 (was £800), utilities £250 (was £200)
- Realistic per-category basePerCapita (Ingredients £44, Entertainment £26, etc.)
- Starting budgets £215 total (~70% of neutral at N=4)
- Budget-as-base model with per-category curves via catCurve() helper
- Activity fatigue: fun/drive supply feeds into fatigue exertion (0.005 coeffs)
- Tech effects wired: chores_rota +15%, cleaner +40%, wellness +20% fatigue recovery
- Debt-aware spending: purchases allowed down to game-over limit, not just £0
- exertBase tuned 0.62→0.59 for ~7.5/week fatigue target
- Simulator: --techs flag for pre-researching techs, updated defaults
- Docs: difficulty squeeze concept, growth economics table, updated design targets