### PR TITLE
Player dashboard fixes: recruit modal, policies, noticeboard, accumul…

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1095,7 +1095,7 @@ function App({ mode = 'player' }) {
           allPolicies={dashboardProps.allPolicies}
           policySlots={dashboardProps.policySlots}
           policyChangesLeft={dashboardProps.policyChangesLeft}
-          onTogglePolicy={(id) => { handleTogglePolicy(id); setActiveModal(null); }}
+          onApplyChanges={async (ids) => { for (const id of ids) await handleTogglePolicy(id); setActiveModal(null); }}
           onClose={() => setActiveModal(null)}
         />
       )}
@@ -1531,11 +1531,17 @@ function App({ mode = 'player' }) {
                   const techPending = !gameState.researchingTech && !gameState.hasResearchedThisWeek && hasAvailableTechs;
                   const policyLimitActive = (gameState.policiesStableWeeks || 0) >= 1 && (gameState.previousPolicies?.length || 0) >= 3;
                   const policyChangesLeft = policyLimitActive ? Math.max(0, (gameState.config?.policyChangesPerWeek ?? 1) - (gameState.policyChangesThisWeek || 0)) : 999;
-                  const hasUnlockedPolicies = (gameState.policyDefinitions || []).some(p => !p.techRequired || gameState.researchedTechs?.includes(p.techRequired));
-                  const policyNotify = hasUnlockedPolicies && policyChangesLeft > 0 && !policyLimitActive;
+                  const unlockedPolicies = (gameState.policyDefinitions || []).filter(p => !p.techRequired || gameState.researchedTechs?.includes(p.techRequired));
+                  const hasUnlockedPolicies = unlockedPolicies.length > 0;
+                  const allUnlockedActive = hasUnlockedPolicies && unlockedPolicies.every(p => (gameState.activePolicies || []).includes(p.id));
+                  const policyNotify = hasUnlockedPolicies && policyChangesLeft > 0 && !policyLimitActive && !allUnlockedActive;
+                  const policyDisabled = !hasUnlockedPolicies || (allUnlockedActive && policyChangesLeft === 0);
+                  const policyLabel = !hasUnlockedPolicies
+                    ? 'Policies (0/0)'
+                    : `Policies (${(gameState.activePolicies?.length || 0)}/${unlockedPolicies.length})`;
                   return (
                     <>
-                <button 
+                <button
                   className="action-grid-btn"
                   onClick={() => { if (!gameState.hasRecruitedThisWeek) { handleOpenRecruitment(); } else { setShowRecruitModal(true); } }}
                 >
@@ -1548,10 +1554,11 @@ function App({ mode = 'player' }) {
                   <span className="action-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94L6.73 20.15a2.1 2.1 0 01-2.88-2.88l6.68-6.68A6 6 0 016.53 2.53l3.77 3.77z"/></svg></span>
                   <span className="action-label">Build</span>
                 </button>
-                <button className="action-grid-btn" onClick={() => setShowPolicyModal(true)}>
+                <button className="action-grid-btn" onClick={() => setShowPolicyModal(true)}
+                  disabled={policyDisabled} style={policyDisabled ? { opacity: 0.4, cursor: 'default' } : {}}>
                   {policyNotify && <span className="action-notify"/>}
                   <span className="action-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 11-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 11-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 11-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 110-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 112.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 114 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 112.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 110 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg></span>
-                  <span className="action-label">Policies{(gameState.activePolicies?.length || 0) > 0 ? ` (${gameState.activePolicies.length})` : ''}</span>
+                  <span className="action-label">{policyLabel}</span>
                 </button>
                 <button className="action-grid-btn" onClick={() => setShowTechModal(true)}>
                   {techPending && <span className="action-notify"/>}
@@ -1928,8 +1935,22 @@ function App({ mode = 'player' }) {
                 </div>
                 <div style={{flex: 1}}>
                   <label style={{fontSize: '0.75rem', color: T.textSecondary, display: 'block', marginBottom: '4px'}}>Identity Labels (when imbalanced)</label>
-                  <div style={{fontSize: '0.65rem', color: '#6a6866', marginBottom: '6px'}}>
-                    Spread &lt; {editConfig?.vibes?.balancedThreshold || 0.18} = Balanced | {editConfig?.vibes?.balancedThreshold || 0.18}–{editConfig?.vibes?.strongImbalanceThreshold || 0.30} = Mild | &gt; {editConfig?.vibes?.strongImbalanceThreshold || 0.30} = Strong
+                  <div style={{display: 'flex', gap: '8px', marginBottom: '6px'}}>
+                    <div style={{flex: 1}}>
+                      <label style={{fontSize: '0.6rem', color: '#6a6866', display: 'block', marginBottom: '2px'}}>Balanced Ratio</label>
+                      <input className="config-table-input" type="number" step="0.05" style={{width: '100%'}}
+                        value={editConfig?.vibes?.balancedRatio ?? 0.6}
+                        onChange={(e) => setEditConfig({...editConfig, vibes: {...editConfig.vibes, balancedRatio: parseFloat(e.target.value)}})} />
+                    </div>
+                    <div style={{flex: 1}}>
+                      <label style={{fontSize: '0.6rem', color: '#6a6866', display: 'block', marginBottom: '2px'}}>Strong Imbalance</label>
+                      <input className="config-table-input" type="number" step="0.05" style={{width: '100%'}}
+                        value={editConfig?.vibes?.strongImbalanceRatio ?? 0.4}
+                        onChange={(e) => setEditConfig({...editConfig, vibes: {...editConfig.vibes, strongImbalanceRatio: parseFloat(e.target.value)}})} />
+                    </div>
+                  </div>
+                  <div style={{fontSize: '0.6rem', color: '#6a6866', marginBottom: '6px'}}>
+                    Min/Max &ge; {editConfig?.vibes?.balancedRatio || 0.6} = Balanced | {editConfig?.vibes?.strongImbalanceRatio || 0.4}–{editConfig?.vibes?.balancedRatio || 0.6} = Mild | &lt; {editConfig?.vibes?.strongImbalanceRatio || 0.4} = Strong
                   </div>
                   <table style={{width: '100%', borderCollapse: 'collapse', fontSize: '0.75rem'}}>
                     <thead>

--- a/client/src/components/MainDashboard.jsx
+++ b/client/src/components/MainDashboard.jsx
@@ -183,7 +183,7 @@ export function MainDashboard({
             {/* Noticeboard (placeholder — spec incoming) */}
             <Panel style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
               <PanelTitle>Noticeboard</PanelTitle>
-              <div className="fl-scroll" style={{ flex: 1, overflowY: 'auto', paddingRight: '4px' }}>
+              <div className="fl-scroll" style={{ flex: 1, overflowY: 'auto', paddingRight: '4px', maxHeight: '280px' }}>
                 {events && events.length > 0 ? events.map((evt, i) => {
                   const es = evtStyle(evt.type);
                   return (

--- a/client/src/components/MiniAccum.jsx
+++ b/client/src/components/MiniAccum.jsx
@@ -6,7 +6,7 @@ import { PixelIcon } from './PixelIcon';
 export function MiniAccum({ value, label, tierLabel, icon, max = 100 }) {
   const [hov, setHov] = useState(false);
   const pct = Math.min(value, max) / max * 100;
-  const fillColor = pct < 40 ? '#5ab87a' : pct < 70 ? '#e8b84a' : '#d45a5a';
+  const fillColor = pct < 25 ? '#5ab87a' : pct < 50 ? '#e8b84a' : '#d45a5a';
   return (
     <div onMouseEnter={() => setHov(true)} onMouseLeave={() => setHov(false)}
       style={{ textAlign: 'center', flex: 1, display: 'flex', flexDirection: 'column', position: 'relative', cursor: 'default' }}>

--- a/client/src/components/PoliciesModal.jsx
+++ b/client/src/components/PoliciesModal.jsx
@@ -2,42 +2,58 @@ import { useState } from 'react';
 import { T, FONT, FONT_BODY, FS } from './theme';
 import { ModalOverlay, ModalHeader, ModalBody, ModalChip } from './ModalShell';
 
-// Checkbox-led policy toggle with commit flow
+// Checkbox-led policy toggle with batch commit flow
 export function PoliciesModal({
   allPolicies,        // [{ id, name, effect, primitive, active, unlocked }]
   policySlots,
   policyChangesLeft,
-  onTogglePolicy,     // (policyId) => void
+  onApplyChanges,     // (policyIds[]) => void
   onClose,
 }) {
-  const [pendingId, setPendingId] = useState(null);
+  const [pendingChanges, setPendingChanges] = useState(new Set());
   const [showConfirm, setShowConfirm] = useState(false);
   const [committed, setCommitted] = useState(false);
 
   const visiblePolicies = (allPolicies || []).filter(p => p.unlocked);
   const activeCount = (allPolicies || []).filter(p => p.active).length;
-  const pendingPolicy = pendingId ? visiblePolicies.find(p => p.id === pendingId) : null;
-  const pendingAction = pendingPolicy ? (pendingPolicy.active ? 'Deactivate' : 'Activate') : '';
   const canChange = policyChangesLeft > 0 && !committed;
+  const changesRemaining = Math.max(0, policyChangesLeft - pendingChanges.size);
 
   const handleToggle = (p) => {
     if (!canChange) return;
-    setPendingId(pendingId === p.id ? null : p.id);
+    const next = new Set(pendingChanges);
+    if (next.has(p.id)) {
+      next.delete(p.id);
+    } else {
+      if (changesRemaining <= 0) return;
+      next.add(p.id);
+    }
+    setPendingChanges(next);
     setShowConfirm(false);
   };
 
   const handleConfirm = () => {
-    if (pendingPolicy) onTogglePolicy(pendingPolicy.id);
+    if (pendingChanges.size > 0) onApplyChanges([...pendingChanges]);
     setShowConfirm(false);
     setCommitted(true);
-    setPendingId(null);
+    setPendingChanges(new Set());
   };
+
+  // Preview what active count would be after pending changes
+  const previewActiveCount = (() => {
+    let count = activeCount;
+    for (const id of pendingChanges) {
+      const p = visiblePolicies.find(v => v.id === id);
+      if (p) count += p.active ? -1 : 1;
+    }
+    return count;
+  })();
 
   return (
     <ModalOverlay onClose={onClose}>
       <ModalHeader title="Policies" onClose={onClose} right={<>
-        <ModalChip label={`${activeCount}/${policySlots} ACTIVE`} color={activeCount > policySlots ? T.negative : T.textSecondary} />
-        <ModalChip label={committed ? '0 CHANGES LEFT' : `${policyChangesLeft} CHANGE LEFT`} color={!canChange ? T.negative : T.textSecondary} />
+        <ModalChip label={`${pendingChanges.size > 0 ? previewActiveCount : activeCount}/${policySlots} ACTIVE`} color={previewActiveCount > policySlots ? T.negative : T.textSecondary} />
+        <ModalChip label={committed ? '0 CHANGES LEFT' : `${changesRemaining} CHANGE${changesRemaining !== 1 ? 'S' : ''} LEFT`} color={changesRemaining === 0 || committed ? T.negative : T.textSecondary} />
       </>} />
       <ModalBody>
         {visiblePolicies.length > 0 ? (
@@ -51,18 +67,20 @@ export function PoliciesModal({
         )}
         <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
           {visiblePolicies.map(p => {
-            const isPending = pendingId === p.id;
+            const isPending = pendingChanges.has(p.id);
             const willBeActive = isPending ? !p.active : p.active;
             const isActive = p.active;
+            const atLimit = !isPending && changesRemaining <= 0;
             const checkColor = isPending
               ? (willBeActive ? T.positive : T.negative)
               : (isActive ? T.positive : T.panelBorder);
             return (
-              <div key={p.id} onClick={() => canChange && handleToggle(p)} style={{
+              <div key={p.id} onClick={() => canChange && !atLimit && handleToggle(p)} style={{
                 background: isPending ? T.accentBg : T.panelBg,
                 border: `2px solid ${isPending ? T.accent : 'transparent'}`,
                 padding: '10px',
-                cursor: canChange ? 'pointer' : 'default',
+                cursor: canChange && (!atLimit || isPending) ? 'pointer' : 'default',
+                opacity: atLimit && !isPending ? 0.5 : 1,
                 display: 'flex', gap: '10px', alignItems: 'flex-start',
                 transition: 'border-color 0.15s, background 0.15s',
               }}>
@@ -101,18 +119,25 @@ export function PoliciesModal({
         </div>
 
         {/* Confirmation popup */}
-        {showConfirm && pendingPolicy && (
+        {showConfirm && pendingChanges.size > 0 && (
           <div style={{
             marginTop: '12px', padding: '14px',
             background: T.bg, border: `2px solid ${T.negative}`,
           }}>
             <p style={{ fontFamily: FONT, fontSize: FS.body, color: T.textPrimary, marginBottom: '8px' }}>
-              Confirm policy change
+              Confirm {pendingChanges.size} policy change{pendingChanges.size !== 1 ? 's' : ''}
             </p>
-            <p style={{ fontFamily: FONT_BODY, fontSize: '12px', color: T.textSecondary, marginBottom: '12px', lineHeight: '1.5' }}>
-              {pendingAction} <span style={{ color: T.textPrimary }}>{pendingPolicy.name}</span>.
-              This uses your policy change for the week — you won't be able to make another until next week.
-            </p>
+            <div style={{ marginBottom: '12px' }}>
+              {[...pendingChanges].map(id => {
+                const p = visiblePolicies.find(v => v.id === id);
+                if (!p) return null;
+                return (
+                  <p key={id} style={{ fontFamily: FONT_BODY, fontSize: '12px', color: T.textSecondary, lineHeight: '1.5' }}>
+                    {p.active ? 'Deactivate' : 'Activate'} <span style={{ color: T.textPrimary }}>{p.name}</span>
+                  </p>
+                );
+              })}
+            </div>
             <div style={{ display: 'flex', gap: '8px' }}>
               <div onClick={handleConfirm} style={{
                 flex: 2, padding: '6px', textAlign: 'center', cursor: 'pointer',
@@ -136,19 +161,19 @@ export function PoliciesModal({
             textAlign: 'center',
           }}>
             <span style={{ fontFamily: FONT, fontSize: FS.label, color: T.positive }}>
-              ✓ Policy change applied
+              ✓ Policy changes applied
             </span>
           </div>
         )}
 
         {/* Commit button */}
-        {pendingId && !showConfirm && !committed && (
+        {pendingChanges.size > 0 && !showConfirm && !committed && (
           <div style={{ marginTop: '12px' }}>
             <div onClick={() => setShowConfirm(true)} style={{
               padding: '8px', textAlign: 'center', cursor: 'pointer',
               background: T.positive, border: `2px solid ${T.positive}`,
               fontFamily: FONT, fontSize: FS.label, color: T.bg,
-            }}>{pendingAction} {pendingPolicy.name}</div>
+            }}>Apply {pendingChanges.size} change{pendingChanges.size !== 1 ? 's' : ''}</div>
           </div>
         )}
       </ModalBody>

--- a/client/src/components/RecruitModal.jsx
+++ b/client/src/components/RecruitModal.jsx
@@ -100,52 +100,48 @@ export function RecruitModal({
                 );
               })}
             </div>
-
-            {/* Confirmation popup */}
-            {showConfirm && selectedCandidate && (
-              <div style={{
-                marginTop: '10px', padding: '10px 14px',
-                background: T.bg, border: `2px solid ${T.negative}`,
-              }}>
-                <p style={{ fontFamily: FONT, fontSize: FS.body, color: T.textPrimary, marginBottom: '4px' }}>
-                  Confirm recruit
-                </p>
-                <p style={{ fontFamily: FONT_BODY, fontSize: '12px', color: T.textSecondary, marginBottom: '8px', lineHeight: '1.4' }}>
-                  Invite <span style={{ color: T.textPrimary }}>{selectedCandidate.name}</span> to join the commune.
-                  This uses your recruit action for the week — they'll arrive next week.
-                </p>
-                <div style={{ display: 'flex', gap: '8px' }}>
-                  <div onClick={handleConfirm} style={{
-                    flex: 2, padding: '5px', textAlign: 'center', cursor: 'pointer',
-                    background: T.positive, border: `2px solid ${T.positive}`,
-                    fontFamily: FONT, fontSize: FS.label, color: T.bg,
-                  }}>Confirm</div>
-                  <div onClick={() => setShowConfirm(false)} style={{
-                    flex: 1, padding: '5px', textAlign: 'center', cursor: 'pointer',
-                    background: T.negative, border: `2px solid ${T.negative}`,
-                    fontFamily: FONT, fontSize: FS.label, color: T.bg,
-                  }}>Cancel</div>
-                </div>
-              </div>
-            )}
-
-            {/* Invite button */}
-            {!showConfirm && (
-              <div style={{ marginTop: '10px' }}>
-                <div onClick={() => selectedId && setShowConfirm(true)} style={{
-                  padding: '7px', textAlign: 'center',
-                  cursor: selectedId ? 'pointer' : 'default',
-                  background: selectedId ? T.positive : T.buttonBg,
-                  border: `2px solid ${selectedId ? T.positive : T.panelBorder}`,
-                  fontFamily: FONT, fontSize: FS.label,
-                  color: selectedId ? T.bg : T.textMuted,
-                  opacity: selectedId ? 1 : 0.5,
-                }}>Invite {selectedCandidate ? selectedCandidate.name : '...'}</div>
-              </div>
-            )}
           </>
         )}
       </ModalBody>
+
+      {/* Pinned bottom: confirmation + invite button (outside scroll area) */}
+      {!noRoom && !already && (
+        <div style={{ padding: '10px 14px', borderTop: `2px solid ${T.panelBorder}`, flexShrink: 0 }}>
+          {showConfirm && selectedCandidate ? (
+            <div>
+              <p style={{ fontFamily: FONT, fontSize: FS.body, color: T.textPrimary, marginBottom: '4px' }}>
+                Confirm recruit
+              </p>
+              <p style={{ fontFamily: FONT_BODY, fontSize: '12px', color: T.textSecondary, marginBottom: '8px', lineHeight: '1.4' }}>
+                Invite <span style={{ color: T.textPrimary }}>{selectedCandidate.name}</span> to join the commune.
+                This uses your recruit action for the week — they'll arrive next week.
+              </p>
+              <div style={{ display: 'flex', gap: '8px' }}>
+                <div onClick={handleConfirm} style={{
+                  flex: 2, padding: '5px', textAlign: 'center', cursor: 'pointer',
+                  background: T.positive, border: `2px solid ${T.positive}`,
+                  fontFamily: FONT, fontSize: FS.label, color: T.bg,
+                }}>Confirm</div>
+                <div onClick={() => setShowConfirm(false)} style={{
+                  flex: 1, padding: '5px', textAlign: 'center', cursor: 'pointer',
+                  background: T.negative, border: `2px solid ${T.negative}`,
+                  fontFamily: FONT, fontSize: FS.label, color: T.bg,
+                }}>Cancel</div>
+              </div>
+            </div>
+          ) : (
+            <div onClick={() => selectedId && setShowConfirm(true)} style={{
+              padding: '7px', textAlign: 'center',
+              cursor: selectedId ? 'pointer' : 'default',
+              background: selectedId ? T.positive : T.buttonBg,
+              border: `2px solid ${selectedId ? T.positive : T.panelBorder}`,
+              fontFamily: FONT, fontSize: FS.label,
+              color: selectedId ? T.bg : T.textMuted,
+              opacity: selectedId ? 1 : 0.5,
+            }}>Invite {selectedCandidate ? selectedCandidate.name : '...'}</div>
+          )}
+        </div>
+      )}
     </ModalOverlay>
   );
 }

--- a/server/config.js
+++ b/server/config.js
@@ -454,8 +454,8 @@ const DEFAULT_HEALTH_CONFIG = {
 };
 
 const DEFAULT_VIBES_CONFIG = {
-  "balancedThreshold": 0.18,
-  "strongImbalanceThreshold": 0.3,
+  "balancedRatio": 0.6,
+  "strongImbalanceRatio": 0.4,
   "tierThresholds": [
     {
       "name": "Shambles",

--- a/server/outcomes.js
+++ b/server/outcomes.js
@@ -86,8 +86,9 @@ function calculateVibes() {
   const spread = sorted[2] - sorted[0];
   const median = sorted[1];
 
-  const isBalanced = spread <= cfg.balancedThreshold;
-  const isStrongImbalance = spread > cfg.strongImbalanceThreshold;
+  const ratio = sorted[2] > 0 ? sorted[0] / sorted[2] : 1;
+  const isBalanced = ratio >= cfg.balancedRatio;
+  const isStrongImbalance = ratio < cfg.strongImbalanceRatio;
 
   let baseTierIndex = 0;
   for (let i = 0; i < cfg.tierThresholds.length; i++) {


### PR DESCRIPTION
…ators, vibes balance

- Recruit modal: pin confirmation/invite button below scroll area so it stays visible
- Policies button: grey out when no unlocked policies or all active, show (N/N) count
- Policies modal: batch multiple changes before committing (up to weekly limit)
- Noticeboard: cap height at 280px with internal scroll
- Accumulator bars: lower traffic-light thresholds (25/50 vs 40/70) for debt metrics
- Vibes balance: switch from absolute spread to min/max ratio system with dev tools inputs