### PR TITLE
Responsive three-column dashboard: ActionPanel | Sky | DataPanel

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,7 +3,7 @@ import './components/dashboard.css';
 import { T, STAT_DISPLAY, BUDGET_DISPLAY, TREE_COLORS, TREE_LABELS } from './components/theme';
 import { TopBar } from './components/TopBar';
 import { ActionPanel } from './components/ActionPanel';
-import { MainDashboard } from './components/MainDashboard';
+import { DataPanel } from './components/DataPanel';
 import { GameOverScreen } from './components/GameOverScreen';
 import { RecruitModal } from './components/RecruitModal';
 import { BuildModal } from './components/BuildModal';
@@ -13,9 +13,23 @@ import FortLlamaLanding from './components/FortLlamaLanding';
 
 const API_BASE = '';
 
+// Responsive width hook — returns current window width, updates on resize
+function useWindowWidth() {
+  const [width, setWidth] = useState(typeof window !== 'undefined' ? window.innerWidth : 1200);
+  useEffect(() => {
+    const handle = () => setWidth(window.innerWidth);
+    window.addEventListener('resize', handle);
+    return () => window.removeEventListener('resize', handle);
+  }, []);
+  return width;
+}
+
 function App({ mode = 'player' }) {
+  const winWidth = useWindowWidth();
+  const layout = winWidth >= 850 ? 'wide' : winWidth >= 600 ? 'medium' : 'narrow';
   const [screen, setScreen] = useState(mode === 'player' ? 'landing' : 'game');
   const [view, setView] = useState('dashboard');
+  const [narrowTab, setNarrowTab] = useState('actions');
   const [gameState, setGameState] = useState(null);
   const [config, setConfig] = useState(null);
   const [editConfig, setEditConfig] = useState(null);
@@ -818,7 +832,7 @@ function App({ mode = 'player' }) {
       rentStep: config.rentStep || 10,
       budgets: budgetInputs,
       isPaused,
-      // MainDashboard
+      // DataPanel
       treasury: Math.round(gameState.treasury || 0),
       income: Math.round(projIncome),
       expenses: Math.round(totalExpenses),
@@ -945,7 +959,8 @@ function App({ mode = 'player' }) {
 
   return (
     <div className="app" style={{ background: T.pageBg, height: '100vh', overflow: 'hidden', display: 'flex', flexDirection: 'column', position: 'relative' }}>
-      {/* Decorative pixel clouds */}
+      {/* Decorative pixel clouds — only on wide layout */}
+      {layout === 'wide' && (
       <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none', zIndex: 0, overflow: 'hidden' }}>
         {/* Large puffy cloud */}
         <div style={{ position: 'absolute', top: '10%', left: '5%', animation: 'fl-drift1 90s linear infinite', animationDelay: '-10s' }}>
@@ -985,86 +1000,90 @@ function App({ mode = 'player' }) {
           </svg>
         </div>
       </div>
+      )}
       <TopBar
-        mode={mode}
-        view={view}
         vibes={dashboardProps?.vibes}
         reputation={dashboardProps?.reputation}
         level={dashboardProps?.level}
         score={dashboardProps?.score}
-        onSwitchView={(v) => {
-          if (v === 'devtools') {
-            setView('devtools');
-            setEditConfig({
-              ...config,
-              health: gameState?.healthConfig,
-              primitives: gameState?.primitiveConfig,
-              vibes: gameState?.vibesConfig,
-              budgetConfig: gameState?.budgetConfig,
-              policyConfig: gameState?.policyConfig,
-              techConfig: gameState?.techConfig
-            });
-          } else {
-            setView(v);
-          }
-        }}
+        layout={layout}
+        narrowTab={narrowTab}
+        onNarrowTab={setNarrowTab}
       />
 
       {gameState.isGameOver && view === 'dashboard' && (
         <GameOverScreen onRestart={handleReset} />
       )}
-      {gameState.isGameOver && view !== 'dashboard' && (
-        <div className="game-over">
-          <h2>GAME OVER</h2>
-          <p>The commune has gone bankrupt! Treasury: {formatCurrency(gameState.treasury)}</p>
-          <button className="btn-reset" onClick={handleReset}>Try Again</button>
-        </div>
-      )}
 
       {view === 'dashboard' && dashboardProps && (
         <div style={{ display: 'flex', flex: 1, overflow: 'hidden', position: 'relative', zIndex: 1 }}>
-          <ActionPanel
-            week={dashboardProps.week}
-            day={dashboardProps.day}
-            time={dashboardProps.time}
-            hasRecruitedThisWeek={dashboardProps.hasRecruitedThisWeek}
-            buildsThisWeek={dashboardProps.buildsThisWeek}
-            buildsPerWeek={dashboardProps.buildsPerWeek}
-            policyChangesLeft={dashboardProps.policyChangesLeft}
-            researchingTech={dashboardProps.researchingTech}
-            rent={dashboardProps.rent}
-            rentTier={dashboardProps.rentTier}
-            rentMin={dashboardProps.rentMin}
-            rentMax={dashboardProps.rentMax}
-            rentStep={dashboardProps.rentStep}
-            budgets={dashboardProps.budgets}
-            isPaused={dashboardProps.isPaused}
-            onOpenModal={handleOpenModal}
-            onRentChange={(val) => setRentInput(String(val))}
-            onRentRelease={() => handleSetRent(rentInput)}
-            onBudgetStep={handleBudgetStep}
-            onStartWeek={handleDismissWeekly}
-            onRestart={() => { if (window.confirm('Are you sure you want to restart the game?')) handleReset(); }}
-          />
-          <MainDashboard
-            treasury={dashboardProps.treasury}
-            income={dashboardProps.income}
-            expenses={dashboardProps.expenses}
-            net={dashboardProps.net}
-            incomeBreakdown={dashboardProps.incomeBreakdown}
-            expenseBreakdown={dashboardProps.expenseBreakdown}
-            healthMetrics={dashboardProps.healthMetrics}
-            metricHistory={dashboardProps.metricHistory}
-            researchedCulture={dashboardProps.researchedCulture}
-            buildings={dashboardProps.buildings}
-            residents={dashboardProps.residents}
-            population={dashboardProps.population}
-            capacity={dashboardProps.capacity}
-            aggregateStats={dashboardProps.aggregateStats}
-            policies={dashboardProps.policies}
-            events={dashboardProps.events}
-            primitives={dashboardProps.primitives}
-          />
+          {/* WIDE: Actions | Sky | Vitals */}
+          {layout === 'wide' && (<>
+            <ActionPanel
+              week={dashboardProps.week} day={dashboardProps.day} time={dashboardProps.time}
+              hasRecruitedThisWeek={dashboardProps.hasRecruitedThisWeek} buildsThisWeek={dashboardProps.buildsThisWeek} buildsPerWeek={dashboardProps.buildsPerWeek}
+              policyChangesLeft={dashboardProps.policyChangesLeft} researchingTech={dashboardProps.researchingTech}
+              rent={dashboardProps.rent} rentTier={dashboardProps.rentTier} rentMin={dashboardProps.rentMin} rentMax={dashboardProps.rentMax} rentStep={dashboardProps.rentStep}
+              budgets={dashboardProps.budgets} isPaused={dashboardProps.isPaused}
+              onOpenModal={handleOpenModal} onRentChange={(val) => setRentInput(String(val))} onRentRelease={() => handleSetRent(rentInput)}
+              onBudgetStep={handleBudgetStep} onStartWeek={handleDismissWeekly}
+              onRestart={() => { if (window.confirm('Are you sure you want to restart the game?')) handleReset(); }}
+            />
+            <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }} />
+            <DataPanel
+              treasury={dashboardProps.treasury} income={dashboardProps.income} expenses={dashboardProps.expenses} net={dashboardProps.net}
+              incomeBreakdown={dashboardProps.incomeBreakdown} expenseBreakdown={dashboardProps.expenseBreakdown}
+              healthMetrics={dashboardProps.healthMetrics} metricHistory={dashboardProps.metricHistory} researchedCulture={dashboardProps.researchedCulture}
+              buildings={dashboardProps.buildings} residents={dashboardProps.residents} population={dashboardProps.population} capacity={dashboardProps.capacity}
+              aggregateStats={dashboardProps.aggregateStats} policies={dashboardProps.policies} events={dashboardProps.events} primitives={dashboardProps.primitives}
+            />
+          </>)}
+
+          {/* MEDIUM: Actions + single-column Vitals, no sky */}
+          {layout === 'medium' && (<>
+            <ActionPanel
+              week={dashboardProps.week} day={dashboardProps.day} time={dashboardProps.time}
+              hasRecruitedThisWeek={dashboardProps.hasRecruitedThisWeek} buildsThisWeek={dashboardProps.buildsThisWeek} buildsPerWeek={dashboardProps.buildsPerWeek}
+              policyChangesLeft={dashboardProps.policyChangesLeft} researchingTech={dashboardProps.researchingTech}
+              rent={dashboardProps.rent} rentTier={dashboardProps.rentTier} rentMin={dashboardProps.rentMin} rentMax={dashboardProps.rentMax} rentStep={dashboardProps.rentStep}
+              budgets={dashboardProps.budgets} isPaused={dashboardProps.isPaused}
+              onOpenModal={handleOpenModal} onRentChange={(val) => setRentInput(String(val))} onRentRelease={() => handleSetRent(rentInput)}
+              onBudgetStep={handleBudgetStep} onStartWeek={handleDismissWeekly}
+              onRestart={() => { if (window.confirm('Are you sure you want to restart the game?')) handleReset(); }}
+            />
+            <DataPanel singleColumn
+              treasury={dashboardProps.treasury} income={dashboardProps.income} expenses={dashboardProps.expenses} net={dashboardProps.net}
+              incomeBreakdown={dashboardProps.incomeBreakdown} expenseBreakdown={dashboardProps.expenseBreakdown}
+              healthMetrics={dashboardProps.healthMetrics} metricHistory={dashboardProps.metricHistory} researchedCulture={dashboardProps.researchedCulture}
+              buildings={dashboardProps.buildings} residents={dashboardProps.residents} population={dashboardProps.population} capacity={dashboardProps.capacity}
+              aggregateStats={dashboardProps.aggregateStats} policies={dashboardProps.policies} events={dashboardProps.events} primitives={dashboardProps.primitives}
+            />
+          </>)}
+
+          {/* NARROW: One panel at a time, toggled */}
+          {layout === 'narrow' && narrowTab === 'actions' && (
+            <div style={{ flex: 1, overflowY: 'auto' }}>
+              <ActionPanel hideCollapse
+                week={dashboardProps.week} day={dashboardProps.day} time={dashboardProps.time}
+                hasRecruitedThisWeek={dashboardProps.hasRecruitedThisWeek} buildsThisWeek={dashboardProps.buildsThisWeek} buildsPerWeek={dashboardProps.buildsPerWeek}
+                policyChangesLeft={dashboardProps.policyChangesLeft} researchingTech={dashboardProps.researchingTech}
+                rent={dashboardProps.rent} rentTier={dashboardProps.rentTier} rentMin={dashboardProps.rentMin} rentMax={dashboardProps.rentMax} rentStep={dashboardProps.rentStep}
+                budgets={dashboardProps.budgets} isPaused={dashboardProps.isPaused}
+                onOpenModal={handleOpenModal} onRentChange={(val) => setRentInput(String(val))} onRentRelease={() => handleSetRent(rentInput)}
+                onBudgetStep={handleBudgetStep} onStartWeek={handleDismissWeekly}
+                onRestart={() => { if (window.confirm('Are you sure you want to restart the game?')) handleReset(); }}
+              />
+            </div>
+          )}
+          {layout === 'narrow' && narrowTab === 'vitals' && (
+            <DataPanel singleColumn hideCollapse
+              treasury={dashboardProps.treasury} income={dashboardProps.income} expenses={dashboardProps.expenses} net={dashboardProps.net}
+              incomeBreakdown={dashboardProps.incomeBreakdown} expenseBreakdown={dashboardProps.expenseBreakdown}
+              healthMetrics={dashboardProps.healthMetrics} metricHistory={dashboardProps.metricHistory} researchedCulture={dashboardProps.researchedCulture}
+              buildings={dashboardProps.buildings} residents={dashboardProps.residents} population={dashboardProps.population} capacity={dashboardProps.capacity}
+              aggregateStats={dashboardProps.aggregateStats} policies={dashboardProps.policies} events={dashboardProps.events} primitives={dashboardProps.primitives}
+            />
+          )}
         </div>
       )}
 

--- a/client/src/components/ActionPanel.jsx
+++ b/client/src/components/ActionPanel.jsx
@@ -12,6 +12,8 @@ export function ActionPanel({
   budgets,             // { [key]: currentValue }
   budgetConfig,        // { [key]: { floor, ceiling } } for stepper bounds
   isPaused,
+  hideCollapse,        // hide collapse toggle (narrow mode)
+  fullWidth,           // unused in final design — ActionPanel stays 240px
   onOpenModal,         // (modalName) => void
   onRentChange,        // (value) => void
   onRentRelease,       // () => void
@@ -25,34 +27,42 @@ export function ActionPanel({
   const budgetEntries = Object.entries(budgets || {});
   const totalBudget = budgetEntries.reduce((s, [, v]) => s + v, 0);
 
-  // Collapsed state — thin stripe with expand arrow
-  if (!actionOpen) {
+  // Collapsed state — thin stripe with expand arrow + vertical label
+  if (!hideCollapse && !actionOpen) {
     return (
       <div onClick={() => setActionOpen(true)} style={{
         width: '36px', flexShrink: 0, background: T.actionBg,
         borderRight: `2px solid ${T.panelBorder}`,
         display: 'flex', flexDirection: 'column', alignItems: 'center',
-        paddingTop: '10px', cursor: 'pointer', gap: '8px',
+        paddingTop: '12px', cursor: 'pointer', gap: '6px',
       }}>
-        <span style={{ fontFamily: FONT, fontSize: FS.brand, color: T.accent }}>►</span>
+        <span style={{ fontFamily: FONT, fontSize: FS.body, color: T.accent }}>{'\u25BA'}</span>
+        <span style={{
+          fontFamily: FONT, fontSize: FS.micro, color: T.accent,
+          writingMode: 'vertical-rl', textOrientation: 'mixed', letterSpacing: '2px',
+        }}>Actions</span>
       </div>
     );
   }
 
   return (
-    <div style={{
-      flex: 1, minWidth: '180px', maxWidth: '300px', borderRight: `2px solid ${T.panelBorder}`,
-      background: T.actionBg, padding: '10px',
-      display: 'flex', flexDirection: 'column', gap: '10px', overflowY: 'auto',
+    <div className="fl-scroll" style={{
+      width: fullWidth ? '100%' : '240px', flexShrink: 0,
+      borderRight: fullWidth ? 'none' : `2px solid ${T.panelBorder}`,
+      background: T.actionBg, padding: '8px 8px 12px',
+      display: 'flex', flexDirection: 'column', gap: '8px',
+      overflowY: 'auto', overflowX: 'hidden',
     }}>
       {/* Collapse toggle */}
-      <div onClick={() => setActionOpen(false)} style={{
+      {!hideCollapse && (
+        <div onClick={() => setActionOpen(false)} style={{
           display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-          cursor: 'pointer', padding: '2px 0 4px', borderBottom: `1px solid ${T.panelBorder}`, marginBottom: '10px',
+          cursor: 'pointer', padding: '2px 0 6px', borderBottom: `1px solid ${T.panelBorder}`,
         }}>
           <span style={{ fontFamily: FONT, fontSize: FS.heading, color: T.accent, letterSpacing: '1px' }}>Actions</span>
-          <span style={{ fontFamily: FONT, fontSize: FS.label, color: T.textMuted }}>◄ Hide</span>
+          <span style={{ fontFamily: FONT, fontSize: FS.label, color: T.accent, opacity: 0.7 }}>{'\u25C4'} Hide</span>
         </div>
+      )}
 
       {/* Clock */}
       <div style={{
@@ -65,8 +75,8 @@ export function ActionPanel({
         <span style={{ fontFamily: FONT_BODY, fontSize: '13px', color: T.textPrimary, letterSpacing: '1px' }}>{time}</span>
       </div>
 
-      {/* 2×2 Action buttons */}
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '6px' }}>
+      {/* 2x2 Action buttons */}
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '5px' }}>
         <ActionButton label="Recruit" icon={<PixelIcon type="recruit" color={T.accentBright} />}
           spent={hasRecruitedThisWeek} onClick={() => onOpenModal('recruit')} />
         <ActionButton label="Build" icon={<PixelIcon type="build" color={T.accentBright} />}
@@ -78,19 +88,19 @@ export function ActionPanel({
       </div>
 
       {/* Rent slider */}
-      <div style={{ background: T.panelBg, border: `2px solid ${T.panelBorder}`, padding: '8px 10px' }}>
-        <span style={{ fontFamily: FONT, fontSize: FS.heading, color: '#fff' }}>Rent</span>
+      <div style={{ background: T.panelBg, border: `2px solid ${T.panelBorder}`, padding: '6px 8px' }}>
+        <span style={{ fontFamily: FONT, fontSize: FS.body, color: '#fff' }}>Rent</span>
         <input className="fl-rent" type="range"
           min={rentMin || 50} max={rentMax || 500} step={rentStep || 10}
           value={rent}
           onChange={e => onRentChange(Number(e.target.value))}
           onMouseUp={onRentRelease}
           onTouchEnd={onRentRelease}
-          style={{ margin: '8px 0 6px' }}
+          style={{ margin: '6px 0 4px' }}
         />
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
           <span style={{ fontFamily: FONT_BODY, fontSize: '13px', color: T.accent }}>{rentTier}</span>
-          <span style={{ fontFamily: FONT_BODY, fontSize: '16px', color: '#fff' }}>£{rent}</span>
+          <span style={{ fontFamily: FONT_BODY, fontSize: '14px', color: '#fff' }}>&pound;{rent}</span>
         </div>
       </div>
 
@@ -98,41 +108,44 @@ export function ActionPanel({
       <div>
         <div onClick={() => setBudgetsOpen(!budgetsOpen)} style={{
           background: T.buttonBg, border: `2px solid ${T.buttonBorder}`,
-          padding: '6px 8px', cursor: 'pointer',
+          padding: '5px 8px', cursor: 'pointer',
           display: 'flex', justifyContent: 'space-between', alignItems: 'center',
         }}>
           <span style={{ fontFamily: FONT, fontSize: FS.body, color: T.textPrimary }}>Budgets</span>
-          <span style={{ fontFamily: FONT, fontSize: FS.body, color: T.textSecondary }}>{budgetsOpen ? '▼' : '►'}</span>
+          <span style={{ fontFamily: FONT, fontSize: FS.body, color: T.textSecondary }}>{budgetsOpen ? '\u25BC' : '\u25BA'}</span>
         </div>
         {budgetsOpen && (
-          <div style={{ background: T.panelBg, border: `2px solid ${T.panelBorder}`, borderTop: 'none', padding: '6px' }}>
+          <div style={{ background: T.panelBg, border: `2px solid ${T.panelBorder}`, borderTop: 'none', padding: '4px 6px' }}>
             {budgetEntries.map(([key, value], i) => {
               const display = BUDGET_DISPLAY[key] || { name: key, color: T.textSecondary };
               return (
                 <div key={key} style={{
-                  display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '4px 0',
+                  display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '3px 0',
                   borderBottom: i < budgetEntries.length - 1 ? '1px solid rgba(70,70,70,0.4)' : 'none',
                 }}>
-                  <span style={{ fontFamily: FONT_BODY, fontSize: '14px', color: T.textSecondary, width: '72px', flexShrink: 0 }}>{display.name}</span>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '3px' }}>
+                  <span style={{
+                    fontFamily: FONT_BODY, fontSize: '13px', color: T.textSecondary,
+                    flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginRight: '6px',
+                  }}>{display.name}</span>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '2px', flexShrink: 0 }}>
                     {['--', '-'].map(btn => (
                       <div key={btn} onClick={() => onBudgetStep(key, btn === '--' ? -10 : -5)} style={{
                         width: '20px', height: '20px', display: 'flex', alignItems: 'center', justifyContent: 'center',
                         background: T.buttonBg, border: `1px solid ${T.buttonBorder}`, cursor: 'pointer',
-                        fontFamily: FONT_BODY, fontSize: '13px', color: T.textSecondary,
+                        fontFamily: FONT_BODY, fontSize: '12px', color: T.textSecondary,
                       }}>{btn}</div>
                     ))}
                     <div style={{
-                      minWidth: '38px', height: '20px', display: 'flex', alignItems: 'center', justifyContent: 'center',
-                      background: 'rgba(0,0,0,0.2)', padding: '0 4px',
+                      width: '38px', height: '20px', display: 'flex', alignItems: 'center', justifyContent: 'center',
+                      background: 'rgba(0,0,0,0.2)',
                     }}>
-                      <span style={{ fontFamily: FONT_BODY, fontSize: '14px', color: T.textPrimary }}>£{value}</span>
+                      <span style={{ fontFamily: FONT_BODY, fontSize: '13px', color: T.textPrimary }}>&pound;{value}</span>
                     </div>
                     {['+', '++'].map(btn => (
                       <div key={btn} onClick={() => onBudgetStep(key, btn === '++' ? 10 : 5)} style={{
                         width: '20px', height: '20px', display: 'flex', alignItems: 'center', justifyContent: 'center',
                         background: T.buttonBg, border: `1px solid ${T.buttonBorder}`, cursor: 'pointer',
-                        fontFamily: FONT_BODY, fontSize: '13px', color: T.textSecondary,
+                        fontFamily: FONT_BODY, fontSize: '12px', color: T.textSecondary,
                       }}>{btn}</div>
                     ))}
                   </div>
@@ -144,32 +157,34 @@ export function ActionPanel({
         {/* Total — always visible */}
         <div style={{
           display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-          padding: '6px 8px',
+          padding: '5px 8px',
           background: T.panelBg, border: `2px solid ${T.panelBorder}`, borderTop: 'none',
         }}>
-          <span style={{ fontFamily: FONT_BODY, fontSize: '14px', color: T.textSecondary }}>Total Budget</span>
-          <span style={{ fontFamily: FONT_BODY, fontSize: '14px', color: T.negative }}>
-            -£{totalBudget}/wk
+          <span style={{ fontFamily: FONT_BODY, fontSize: '13px', color: T.textSecondary }}>Total</span>
+          <span style={{ fontFamily: FONT_BODY, fontSize: '13px', color: T.negative }}>
+            -&pound;{totalBudget}/wk
           </span>
         </div>
       </div>
 
       {/* Start Week + Restart */}
-      <div onClick={isPaused ? onStartWeek : undefined} style={{
-        background: '#3a7a5a', padding: '10px 8px', textAlign: 'center',
-        cursor: isPaused ? 'pointer' : 'default',
-        border: '2px solid #5aaa7a',
-        opacity: isPaused ? 1 : 0.5,
-        display: 'flex', alignItems: 'center', justifyContent: 'center',
-      }}>
-        <span style={{ fontFamily: FONT, fontSize: FS.heading, color: '#fff', letterSpacing: '1px' }}>Start Week</span>
-      </div>
-      <div onClick={onRestart} style={{
-        background: 'rgba(160,70,70,0.35)', border: '2px solid rgba(196,126,126,0.5)',
-        padding: '10px 8px', textAlign: 'center', cursor: 'pointer',
-        display: 'flex', alignItems: 'center', justifyContent: 'center',
-      }}>
-        <span style={{ fontFamily: FONT, fontSize: FS.heading, color: T.negative, letterSpacing: '1px' }}>Restart Game</span>
+      <div style={{ paddingTop: '4px' }}>
+        <div onClick={isPaused ? onStartWeek : undefined} style={{
+          background: '#3a7a5a', padding: '10px 6px', textAlign: 'center',
+          cursor: isPaused ? 'pointer' : 'default',
+          border: '2px solid #5aaa7a',
+          opacity: isPaused ? 1 : 0.5,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}>
+          <span style={{ fontFamily: FONT, fontSize: FS.heading, color: '#fff', letterSpacing: '1px' }}>Start Week</span>
+        </div>
+        <div onClick={onRestart} style={{
+          background: 'rgba(160,70,70,0.35)', border: '2px solid rgba(196,126,126,0.5)',
+          marginTop: '4px', padding: '7px 6px', textAlign: 'center', cursor: 'pointer',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}>
+          <span style={{ fontFamily: FONT, fontSize: FS.label, color: T.negative, letterSpacing: '1px' }}>Restart</span>
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/DataPanel.jsx
+++ b/client/src/components/DataPanel.jsx
@@ -1,0 +1,313 @@
+import { useState } from 'react';
+import { T, FONT, FONT_BODY, FS, evtStyle } from './theme';
+import { Panel, PanelTitle } from './Panel';
+import { PixelIcon } from './PixelIcon';
+import { Sparkline } from './Sparkline';
+import { SegBar } from './SegBar';
+import { MiniGauge } from './MiniGauge';
+import { MiniAccum } from './MiniAccum';
+import { TreasuryRow } from './TreasuryRow';
+import { PolicyChip } from './PolicyChip';
+import { ResidentChip } from './ResidentChip';
+
+// Collapsible right-hand data panel: Treasury, Culture, Systems | Noticeboard, Residents, Buildings
+export function DataPanel({
+  // Treasury
+  treasury, income, expenses, net, incomeBreakdown, expenseBreakdown,
+  // Culture / Health metrics
+  healthMetrics, metricHistory, researchedCulture,
+  // Buildings
+  buildings,
+  // Residents
+  residents, population, capacity,
+  // Aggregate stats
+  aggregateStats,
+  // Policies
+  policies,
+  // Noticeboard events
+  events,
+  // Primitives (systems panel)
+  primitives,
+  // Layout props
+  singleColumn,
+  hideCollapse,
+}) {
+  const [dataOpen, setDataOpen] = useState(true);
+  const [buildingsOpen, setBuildingsOpen] = useState(true);
+  const [statsOpen, setStatsOpen] = useState(false);
+
+  const ls = healthMetrics?.livingStandards ?? 0;
+  const pr = healthMetrics?.productivity ?? 0;
+  const pt = healthMetrics?.partytime ?? 0;
+
+  // Collapsed state — thin vertical strip
+  if (!hideCollapse && !dataOpen) {
+    return (
+      <div onClick={() => setDataOpen(true)} style={{
+        width: '36px', flexShrink: 0,
+        marginLeft: singleColumn ? 'auto' : undefined,
+        background: T.actionBg, borderLeft: `2px solid ${T.panelBorder}`,
+        display: 'flex', flexDirection: 'column', alignItems: 'center',
+        paddingTop: '12px', cursor: 'pointer', gap: '6px',
+      }}>
+        <span style={{ fontFamily: FONT, fontSize: FS.body, color: T.accent }}>{'\u25C4'}</span>
+        <span style={{
+          fontFamily: FONT, fontSize: FS.micro, color: T.accent,
+          writingMode: 'vertical-rl', textOrientation: 'mixed', letterSpacing: '2px',
+        }}>Vitals</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fl-scroll" style={{
+      width: singleColumn ? '100%' : '580px',
+      maxWidth: singleColumn ? '300px' : undefined,
+      flexShrink: singleColumn ? 1 : 0,
+      marginLeft: singleColumn ? 'auto' : undefined,
+      borderLeft: `2px solid ${T.panelBorder}`,
+      background: T.actionBg, padding: '10px',
+      display: 'flex', flexDirection: 'column', gap: '10px',
+      overflowY: 'auto',
+    }}>
+      {/* Collapse toggle */}
+      {!hideCollapse && (
+        <div onClick={() => setDataOpen(false)} style={{
+          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+          cursor: 'pointer', padding: '2px 0 4px',
+          borderBottom: `1px solid ${T.panelBorder}`, marginBottom: '4px',
+        }}>
+          <span style={{ fontFamily: FONT, fontSize: FS.heading, color: T.accent, letterSpacing: '1px' }}>Vitals</span>
+          <span style={{ fontFamily: FONT, fontSize: FS.label, color: T.accent, opacity: 0.7 }}>Hide {'\u25BA'}</span>
+        </div>
+      )}
+
+      {/* Two-column or single-column content */}
+      <div style={{ display: 'flex', flexDirection: singleColumn ? 'column' : 'row', gap: '10px' }}>
+
+        {/* LEFT COLUMN: Treasury → Culture → Systems */}
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '10px' }}>
+
+          {/* Treasury */}
+          <Panel>
+            <PanelTitle>Treasury</PanelTitle>
+            <TreasuryRow label="Balance" val={`\u00A3${(treasury || 0).toLocaleString()}`} color={(treasury || 0) >= 0 ? T.positive : T.negative} />
+            <TreasuryRow label="Income" val={`\u00A3${(income || 0).toLocaleString()}`} color={T.positive} breakdown={incomeBreakdown} />
+            <TreasuryRow label="Expenses" val={`-\u00A3${(expenses || 0).toLocaleString()}`} color={T.negative} breakdown={expenseBreakdown} />
+            <div style={{
+              display: 'flex', justifyContent: 'space-between', padding: '5px 0 0',
+              marginTop: '2px', borderTop: `1px solid ${T.panelBorderLight}`,
+            }}>
+              <span style={{ fontFamily: FONT_BODY, fontSize: '13px', color: T.textSecondary }}>Net</span>
+              <span style={{ fontFamily: FONT_BODY, fontSize: '15px', color: (net || 0) >= 0 ? T.positive : T.negative }}>
+                &pound;{net || 0}
+              </span>
+            </div>
+          </Panel>
+
+          {/* Culture */}
+          <Panel>
+            <PanelTitle>Culture</PanelTitle>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+              {[
+                { label: 'Living Std', val: ls, color: T.ls, data: metricHistory?.map(d => d.ls) },
+                { label: 'Productivity', val: pr, color: T.pr, data: metricHistory?.map(d => d.pr) },
+                { label: 'Leisure', val: pt, color: T.pt, data: metricHistory?.map(d => d.pt) },
+              ].map(m => (
+                <div key={m.label} style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                  <span style={{
+                    fontFamily: FONT, fontSize: FS.micro, color: T.bg,
+                    background: m.color, padding: '2px 5px', whiteSpace: 'nowrap',
+                  }}>{m.label}</span>
+                  <div style={{ flex: 1 }}>
+                    <Sparkline data={m.data} color={m.color} width={68} height={16} />
+                  </div>
+                  <span style={{
+                    fontFamily: FONT_BODY, fontSize: '16px', color: m.color,
+                    width: '28px', textAlign: 'right',
+                  }}>{m.val}</span>
+                </div>
+              ))}
+            </div>
+            {/* Culture trophies */}
+            {researchedCulture && researchedCulture.length > 0 && (
+              <>
+                <div style={{ borderTop: `1px solid ${T.panelBorder}`, margin: '10px 0 8px' }} />
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+                  {researchedCulture.map(c => {
+                    const treeColor = c.tree === 'livingStandards' ? T.ls : c.tree === 'productivity' ? T.pr : T.pt;
+                    return (
+                      <div key={c.id} style={{
+                        display: 'flex', alignItems: 'center', gap: '4px',
+                        background: `${treeColor}12`, border: `1px solid ${treeColor}33`,
+                        padding: '3px 7px 3px 5px',
+                      }}>
+                        <PixelIcon type="trophy" size={10} color={treeColor} />
+                        <span style={{ fontFamily: FONT, fontSize: FS.micro, color: treeColor }}>{c.badge}</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </>
+            )}
+          </Panel>
+
+          {/* Systems — stacked groups */}
+          <Panel style={{ overflow: 'visible' }}>
+            <PanelTitle>Systems</PanelTitle>
+            {/* Group 1: Nutrition / Fun / Drive (seg bars) */}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', overflow: 'visible' }}>
+              {[
+                { name: 'Nutrition', key: 'nutrition', icon: 'nutrition' },
+                { name: 'Fun', key: 'fun', icon: 'fun' },
+                { name: 'Drive', key: 'drive', icon: 'drive' },
+              ].map(c => {
+                const prim = primitives?.[c.key];
+                if (!prim) return null;
+                return (
+                  <div key={c.name} style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                    <div style={{ width: '18px', display: 'flex', justifyContent: 'center' }}>
+                      <PixelIcon type={c.icon} size={14} />
+                    </div>
+                    <span style={{
+                      fontFamily: FONT, fontSize: FS.micro, color: T.textPrimary,
+                      width: '80px', flexShrink: 0, textTransform: 'uppercase',
+                    }}>{c.name}</span>
+                    <SegBar value={prim.value} threshold={prim.threshold} tierLabel={prim.tier} />
+                  </div>
+                );
+              })}
+            </div>
+            {/* Group 2: Clean / Upkeep / Fatigue (accumulators) */}
+            <div style={{ borderTop: `1px solid ${T.panelBorder}`, margin: '10px 0' }} />
+            <div style={{ display: 'flex', gap: '10px', overflow: 'visible', paddingTop: '4px' }}>
+              <MiniAccum value={primitives?.cleanliness?.value ?? 0} label="CLEAN" tierLabel={primitives?.cleanliness?.tier} icon="clean" />
+              <MiniAccum value={primitives?.maintenance?.value ?? 0} label="UPKEEP" tierLabel={primitives?.maintenance?.tier} icon="upkeep" />
+              <MiniAccum value={primitives?.fatigue?.value ?? 0} label="FATIGUE" tierLabel={primitives?.fatigue?.tier} icon="fatigue" />
+            </div>
+            {/* Group 3: Crowding / Noise (gauges) */}
+            <div style={{ borderTop: `1px solid ${T.panelBorder}`, margin: '10px 0' }} />
+            <div style={{ display: 'flex', gap: '10px', overflow: 'visible', paddingTop: '4px' }}>
+              <MiniGauge value={primitives?.crowding?.value ?? 0} label="CROWDING" tierLabel={primitives?.crowding?.tier} />
+              <MiniGauge value={primitives?.noise?.value ?? 0} label="NOISE" tierLabel={primitives?.noise?.tier} />
+            </div>
+          </Panel>
+        </div>
+
+        {/* RIGHT COLUMN: Noticeboard → Residents → Buildings */}
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '10px' }}>
+
+          {/* Noticeboard */}
+          <Panel style={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}>
+            <PanelTitle>Noticeboard</PanelTitle>
+            <div className="fl-scroll" style={{ flex: 1, overflowY: 'auto', paddingRight: '4px', maxHeight: '280px' }}>
+              {events && events.length > 0 ? events.map((evt, i) => {
+                const es = evtStyle(evt.type);
+                return (
+                  <div key={i} style={{
+                    display: 'flex', alignItems: 'flex-start', gap: '6px', padding: '3px 0',
+                    borderBottom: i < events.length - 1 ? '1px solid rgba(70,70,70,0.35)' : 'none',
+                  }}>
+                    <span style={{ color: es.color, fontFamily: FONT, fontSize: FS.body, width: '12px', textAlign: 'center', flexShrink: 0 }}>{es.icon}</span>
+                    <span style={{ fontSize: '13px', fontFamily: FONT_BODY, color: '#fff', lineHeight: '1.5', flex: 1 }}>{evt.text}</span>
+                    <span style={{ fontFamily: FONT, fontSize: FS.micro, color: T.textMuted, flexShrink: 0 }}>W{evt.week}</span>
+                  </div>
+                );
+              }) : (
+                <span style={{ fontSize: '12px', color: T.textMuted, fontStyle: 'italic', fontFamily: FONT_BODY }}>
+                  No notices yet.
+                </span>
+              )}
+            </div>
+          </Panel>
+
+          {/* Residents */}
+          <Panel>
+            <PanelTitle right={
+              <span style={{ fontFamily: FONT_BODY, fontSize: '14px', color: T.textPrimary }}>{population}/{capacity}</span>
+            }>Residents</PanelTitle>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginBottom: '6px' }}>
+              {residents && residents.map(r => (
+                <ResidentChip key={r.name} resident={r} />
+              ))}
+            </div>
+            {/* Collapsible stats */}
+            {aggregateStats && (
+              <>
+                <div onClick={() => setStatsOpen(!statsOpen)} style={{
+                  display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                  cursor: 'pointer', padding: '4px 0',
+                  borderTop: `1px solid ${T.panelBorder}`,
+                }}>
+                  <span style={{ fontFamily: FONT_BODY, fontSize: '12px', color: T.textSecondary, letterSpacing: '1px', textTransform: 'uppercase' }}>Stats</span>
+                  <span style={{
+                    fontFamily: FONT, fontSize: FS.label, color: T.textSecondary,
+                    transition: 'transform 0.2s',
+                    transform: statsOpen ? 'rotate(0)' : 'rotate(-90deg)',
+                  }}>{'\u25BC'}</span>
+                </div>
+                {statsOpen && (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '2px', marginBottom: '4px' }}>
+                    {Object.entries(aggregateStats).map(([skill, val]) => (
+                      <div key={skill} style={{ display: 'flex', justifyContent: 'space-between', padding: '1px 0' }}>
+                        <span style={{ fontFamily: FONT_BODY, fontSize: '12px', color: T.textSecondary, textTransform: 'uppercase' }}>{skill}</span>
+                        <span style={{ fontFamily: FONT_BODY, fontSize: '13px', color: val > 0 ? T.positive : val < 0 ? T.negative : T.textSecondary }}>
+                          {val > 0 ? `+${val}%` : `${val}%`}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+            {/* Policies */}
+            <div style={{ paddingTop: '6px', borderTop: `1px solid ${T.panelBorder}` }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '6px' }}>
+                <span style={{ fontFamily: FONT_BODY, fontSize: '12px', color: T.textSecondary, letterSpacing: '1px', textTransform: 'uppercase' }}>Policies</span>
+                <span style={{ fontFamily: FONT_BODY, fontSize: '12px', color: T.textPrimary }}>
+                  {policies ? policies.filter(p => p.active !== false).length : 0}/3
+                </span>
+              </div>
+              {(!policies || policies.length === 0) ? (
+                <span style={{ fontSize: '12px', color: T.textMuted, fontStyle: 'italic', fontFamily: FONT_BODY }}>None active</span>
+              ) : (
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
+                  {policies.map((p, i) => (
+                    <PolicyChip key={i} policy={p} />
+                  ))}
+                </div>
+              )}
+            </div>
+          </Panel>
+
+          {/* Buildings */}
+          <Panel style={{ flex: buildingsOpen ? 1 : undefined }}>
+            <div onClick={() => setBuildingsOpen(!buildingsOpen)} style={{
+              display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+              marginBottom: buildingsOpen ? '10px' : 0, cursor: 'pointer',
+            }}>
+              <span style={{ fontFamily: FONT, fontSize: FS.heading, color: T.accent, letterSpacing: '1px' }}>Buildings</span>
+              <span style={{
+                fontFamily: FONT, fontSize: FS.label, color: T.textSecondary,
+                transition: 'transform 0.2s', transform: buildingsOpen ? 'rotate(0)' : 'rotate(-90deg)',
+              }}>{'\u25BC'}</span>
+            </div>
+            {buildingsOpen && buildings && buildings.map((b, i) => (
+              <div key={b.name} style={{
+                display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '3px 0',
+                borderBottom: i < buildings.length - 1 ? '1px solid rgba(70,70,70,0.4)' : 'none',
+              }}>
+                <span style={{ fontFamily: FONT_BODY, fontSize: '13px', color: b.status === 'pending' ? T.textMuted : T.textSecondary }}>{b.name}</span>
+                {b.status === 'pending' ? (
+                  <span style={{ fontFamily: FONT, fontSize: FS.micro, color: T.bg, background: T.accentBright, padding: '1px 4px' }}>Pending</span>
+                ) : (
+                  <span style={{ fontFamily: FONT_BODY, fontSize: '13px', color: T.textPrimary }}>{b.count} ({b.cap})</span>
+                )}
+              </div>
+            ))}
+          </Panel>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/MiniAccum.jsx
+++ b/client/src/components/MiniAccum.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { T, FONT, FS, tierColor } from './theme';
+import { T, FONT, FONT_BODY, FS, tierColor } from './theme';
 import { PixelIcon } from './PixelIcon';
 
 // Vertical bottom-up fill accumulator for cleanliness/maintenance/fatigue
@@ -25,10 +25,10 @@ export function MiniAccum({ value, label, tierLabel, icon, max = 100 }) {
       <div style={{ fontFamily: FONT, fontSize: FS.micro, color: T.textPrimary, marginTop: '4px' }}>{label}</div>
       {hov && (
         <div style={{
-          position: 'absolute', top: '-18px', left: '50%', transform: 'translateX(-50%)',
-          fontFamily: FONT, fontSize: FS.label, color: tierColor(tierLabel),
+          position: 'absolute', top: '-22px', left: '50%', transform: 'translateX(-50%)',
+          fontFamily: FONT_BODY, fontSize: '12px', color: tierColor(tierLabel),
           background: T.panelBg, border: `1px solid ${T.panelBorder}`,
-          padding: '2px 5px', whiteSpace: 'nowrap', zIndex: 10,
+          padding: '2px 6px', whiteSpace: 'nowrap', zIndex: 10,
         }}>{tierLabel} ({value}/{max})</div>
       )}
     </div>

--- a/client/src/components/MiniGauge.jsx
+++ b/client/src/components/MiniGauge.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { T, FONT, FS, tierColor } from './theme';
+import { T, FONT, FONT_BODY, FS, tierColor } from './theme';
 
 // Semi-circular 10-segment arc gauge for crowding/noise
 export function MiniGauge({ value, label, tierLabel }) {
@@ -42,10 +42,10 @@ export function MiniGauge({ value, label, tierLabel }) {
       <div style={{ fontFamily: FONT, fontSize: FS.micro, color: T.textPrimary, marginTop: '4px' }}>{label}</div>
       {hov && (
         <div style={{
-          position: 'absolute', top: '-18px', left: '50%', transform: 'translateX(-50%)',
-          fontFamily: FONT, fontSize: FS.label, color: tierColor(tierLabel),
+          position: 'absolute', top: '-22px', left: '50%', transform: 'translateX(-50%)',
+          fontFamily: FONT_BODY, fontSize: '12px', color: tierColor(tierLabel),
           background: T.panelBg, border: `1px solid ${T.panelBorder}`,
-          padding: '2px 5px', whiteSpace: 'nowrap', zIndex: 10,
+          padding: '2px 6px', whiteSpace: 'nowrap', zIndex: 10,
         }}>{tierLabel} ({value})</div>
       )}
     </div>

--- a/client/src/components/ResidentChip.jsx
+++ b/client/src/components/ResidentChip.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { T, FONT, FS } from './theme';
+import { T, FONT, FONT_BODY, FS } from './theme';
 
 // Name tag with skill hover popup showing all resident stats
 export function ResidentChip({ resident }) {
@@ -9,7 +9,7 @@ export function ResidentChip({ resident }) {
     <span
       onMouseEnter={() => setHov(true)} onMouseLeave={() => setHov(false)}
       style={{
-        fontFamily: FONT, fontSize: FS.body, padding: '5px 10px',
+        fontFamily: FONT_BODY, fontSize: '13px', padding: '4px 8px',
         border: `1px solid ${hov ? T.accent : T.panelBorderLight}`,
         background: hov ? 'rgba(212,160,53,0.1)' : 'rgba(154,150,144,0.04)',
         color: T.textPrimary, cursor: 'default',
@@ -24,12 +24,12 @@ export function ResidentChip({ resident }) {
           padding: '8px 10px', zIndex: 30, minWidth: '150px', whiteSpace: 'nowrap',
           boxShadow: '0 4px 12px rgba(0,0,0,0.5)',
         }}>
-          <div style={{ fontSize: FS.body, color: T.accent, marginBottom: '4px', textAlign: 'center' }}>{resident.name}</div>
+          <div style={{ fontFamily: FONT, fontSize: FS.body, color: T.accent, marginBottom: '4px', textAlign: 'center' }}>{resident.name}</div>
           <div style={{ height: '1px', background: T.panelBorder, marginBottom: '4px' }} />
           {Object.entries(resident.skills).map(([skill, val]) => (
             <div key={skill} style={{ display: 'flex', justifyContent: 'space-between', gap: '16px', padding: '1px 0' }}>
-              <span style={{ fontSize: FS.micro, color: T.textSecondary, textTransform: 'uppercase' }}>{skill}</span>
-              <span style={{ fontSize: FS.label, color: val > 0 ? T.positive : val < 0 ? T.negative : T.textSecondary }}>
+              <span style={{ fontFamily: FONT_BODY, fontSize: '12px', color: T.textSecondary, textTransform: 'uppercase' }}>{skill}</span>
+              <span style={{ fontFamily: FONT_BODY, fontSize: '13px', color: val > 0 ? T.positive : val < 0 ? T.negative : T.textSecondary }}>
                 {val > 0 ? `+${val}` : val}
               </span>
             </div>

--- a/client/src/components/SegBar.jsx
+++ b/client/src/components/SegBar.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { T, FONT, FS, tierColor } from './theme';
+import { T, FONT_BODY, FS, tierColor } from './theme';
 
 // Traffic-light gradient: red → amber → green based on segment position
 function segGradient(i, total) {
@@ -45,10 +45,10 @@ export function SegBar({ value, max = 100, threshold, tierLabel }) {
       )}
       {hovered && (
         <div style={{
-          position: 'absolute', top: '-18px', left: '50%', transform: 'translateX(-50%)',
-          fontFamily: FONT, fontSize: FS.label, color: tierLabel ? tierColor(tierLabel) : T.textPrimary,
+          position: 'absolute', top: '-22px', left: '50%', transform: 'translateX(-50%)',
+          fontFamily: FONT_BODY, fontSize: '12px', color: tierLabel ? tierColor(tierLabel) : T.textPrimary,
           background: T.panelBg, border: `1px solid ${T.panelBorder}`,
-          padding: '2px 5px', whiteSpace: 'nowrap', zIndex: 10,
+          padding: '2px 6px', whiteSpace: 'nowrap', zIndex: 10,
         }}>{tierLabel ? `${tierLabel} (${value})` : `${value} / ${max}`}</div>
       )}
     </div>

--- a/client/src/components/TopBar.jsx
+++ b/client/src/components/TopBar.jsx
@@ -1,65 +1,130 @@
+import React from 'react';
 import { T, FONT, FS } from './theme';
 import logoSvg from '../assets/fort-llama-icon.svg';
 
-// Fixed top bar: brand, dashboard/dev-tools tabs, vibes + score status strip
-export function TopBar({ mode, view, vibes, reputation, level, score, onSwitchView }) {
-  const tabs = mode === 'dev' ? ['dashboard', 'devtools'] : ['dashboard'];
+// Fixed top bar: brand + vibes/score status strip
+// Layout-aware: renders differently for wide, medium, narrow breakpoints
+export function TopBar({ vibes, reputation, level, score, layout, narrowTab, onNarrowTab }) {
+  const stats = [
+    { k: 'VIBE', v: vibes },
+    { k: 'REP', v: reputation },
+    { k: 'LVL', v: level },
+    { k: 'SCORE', v: (score || 0).toLocaleString() },
+  ];
 
-  return (
+  const logoRow = (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexShrink: 0 }}>
+      <img src={logoSvg} alt="Fort Llama" style={{ width: '36px', height: '36px', imageRendering: 'pixelated' }} />
+      <span style={{ fontSize: FS.brand, color: T.accentBright, letterSpacing: '2px', fontFamily: FONT }}>Fort Llama</span>
+    </div>
+  );
+
+  /* Single-row stats bar (used in wide + medium) */
+  const statsRow = (
     <div style={{
-      display: 'flex', alignItems: 'center', flexWrap: 'wrap',
-      padding: '6px 14px', minHeight: '42px',
-      background: T.actionBg, borderBottom: `2px solid ${T.panelBorder}`, gap: '8px',
-      position: 'relative', zIndex: 1,
+      display: 'flex', alignItems: 'center', gap: '10px', padding: '4px 12px',
+      background: 'transparent', border: `1px solid ${T.accent}`,
+      ...(layout === 'wide' ? { flexShrink: 1, minWidth: 0, overflow: 'hidden' } : {}),
     }}>
-      {/* Brand + Tabs */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexShrink: 0 }}>
-        <img src={logoSvg} alt="Fort Llama" style={{ width: '36px', height: '36px', imageRendering: 'pixelated' }} />
-        <span style={{ fontSize: FS.brand, color: T.accentBright, letterSpacing: '2px', fontFamily: FONT }}>Fort Llama</span>
-        <div style={{ display: 'flex', gap: '4px' }}>
-          {tabs.map(tab => {
-            const active = view === tab;
-            const label = tab === 'dashboard' ? 'Dashboard' : 'Dev Tools';
-            return (
-              <span key={tab} onClick={() => onSwitchView(tab)} style={{
-                fontFamily: FONT, fontSize: FS.body, padding: '4px 10px',
-                background: active ? T.accent : 'transparent',
-                color: active ? '#fff' : T.textSecondary,
-                border: `1px solid ${active ? T.accent : T.panelBorder}`, cursor: 'pointer',
-              }}>{label}</span>
-            );
-          })}
+      {stats.map((item, i, arr) => (
+        <React.Fragment key={item.k}>
+          <div style={{
+            display: 'flex', alignItems: 'baseline', gap: '4px',
+            flexShrink: item.k === 'SCORE' ? 0 : 1, minWidth: 0,
+          }}>
+            <span style={{ fontFamily: FONT, fontSize: FS.micro, color: T.textMuted, letterSpacing: '1px' }}>{item.k}</span>
+            <span style={{
+              fontFamily: FONT, fontSize: FS.body, color: '#fff',
+              whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+              ...(item.k === 'SCORE' ? { minWidth: '52px', textAlign: 'right' } : {}),
+            }}>{item.v}</span>
+          </div>
+          {i < arr.length - 1 && <div style={{ width: '1px', height: '14px', background: T.accent, flexShrink: 0 }} />}
+        </React.Fragment>
+      ))}
+    </div>
+  );
+
+  /* 2x2 grid stats (used in narrow) */
+  const statsGrid = (
+    <div style={{
+      display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4px 12px',
+      padding: '4px 12px', border: `1px solid ${T.accent}`, overflow: 'hidden',
+    }}>
+      {stats.map(item => (
+        <div key={item.k} style={{
+          display: 'flex', alignItems: 'baseline', gap: '4px', minWidth: 0, overflow: 'hidden',
+        }}>
+          <span style={{ fontFamily: FONT, fontSize: FS.micro, color: T.textMuted, letterSpacing: '1px' }}>{item.k}</span>
+          <span style={{
+            fontFamily: FONT, fontSize: FS.body, color: '#fff',
+            whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+          }}>{item.v}</span>
+        </div>
+      ))}
+    </div>
+  );
+
+  /* WIDE: single row — logo | spacer | stats */
+  if (layout === 'wide') {
+    return (
+      <div style={{
+        display: 'flex', alignItems: 'center', flexWrap: 'nowrap',
+        padding: '6px 14px', height: '42px', flexShrink: 0,
+        background: T.actionBg, borderBottom: `2px solid ${T.panelBorder}`,
+        gap: '8px', position: 'relative', zIndex: 1,
+      }}>
+        {logoRow}
+        <div style={{ flex: 1, minWidth: 0 }} />
+        {statsRow}
+      </div>
+    );
+  }
+
+  /* MEDIUM: two rows — logo on top, stats below */
+  if (layout === 'medium') {
+    return (
+      <div style={{
+        display: 'flex', flexDirection: 'column', flexShrink: 0,
+        background: T.actionBg, borderBottom: `2px solid ${T.panelBorder}`,
+        position: 'relative', zIndex: 1,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', padding: '6px 14px', height: '42px' }}>
+          {logoRow}
+        </div>
+        <div style={{ padding: '0 14px 6px' }}>
+          {statsRow}
         </div>
       </div>
+    );
+  }
 
-      {/* Spacer */}
-      <div style={{ flex: 1 }} />
-
-      {/* Vibes + Score strip */}
-      <div style={{
-        display: 'flex', alignItems: 'center', gap: '14px',
-        padding: '5px 16px', flexShrink: 1, minWidth: 0, overflow: 'hidden',
-        background: 'transparent', border: `1px solid ${T.accent}`,
-      }}>
-        <div style={{ display: 'flex', alignItems: 'baseline', gap: '5px' }}>
-          <span style={{ fontFamily: FONT, fontSize: FS.micro, color: T.textMuted, letterSpacing: '1px' }}>VIBE</span>
-          <span style={{ fontFamily: FONT, fontSize: FS.brand, color: '#fff' }}>{vibes}</span>
-        </div>
-        <div style={{ width: '1px', height: '16px', background: T.accent }} />
-        <div style={{ display: 'flex', alignItems: 'baseline', gap: '5px' }}>
-          <span style={{ fontFamily: FONT, fontSize: FS.micro, color: T.textMuted, letterSpacing: '1px' }}>REP</span>
-          <span style={{ fontFamily: FONT, fontSize: FS.brand, color: '#fff' }}>{reputation}</span>
-        </div>
-        <div style={{ width: '1px', height: '16px', background: T.accent }} />
-        <div style={{ display: 'flex', alignItems: 'baseline', gap: '4px' }}>
-          <span style={{ fontFamily: FONT, fontSize: FS.micro, color: T.textMuted }}>LVL</span>
-          <span style={{ fontFamily: FONT, fontSize: FS.brand, color: '#fff' }}>{level}</span>
-        </div>
-        <div style={{ width: '1px', height: '16px', background: T.accent }} />
-        <div style={{ display: 'flex', alignItems: 'baseline', gap: '5px' }}>
-          <span style={{ fontFamily: FONT, fontSize: FS.micro, color: T.textMuted, letterSpacing: '1px' }}>SCORE</span>
-          <span style={{ fontFamily: FONT, fontSize: FS.brand, color: '#fff', minWidth: '72px', textAlign: 'right' }}>{(score || 0).toLocaleString()}</span>
-        </div>
+  /* NARROW: logo row, 2x2 stats grid, then Actions/Vitals tabs */
+  return (
+    <div style={{
+      display: 'flex', flexDirection: 'column', flexShrink: 0,
+      background: T.actionBg, borderBottom: `2px solid ${T.panelBorder}`,
+      position: 'relative', zIndex: 1,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', padding: '6px 14px', height: '42px' }}>
+        {logoRow}
+      </div>
+      <div style={{ padding: '0 14px 6px' }}>
+        {statsGrid}
+      </div>
+      <div style={{ display: 'flex', borderTop: `1px solid ${T.panelBorder}` }}>
+        {[{ key: 'actions', label: 'Actions' }, { key: 'vitals', label: 'Vitals' }].map(t => (
+          <div key={t.key} onClick={() => onNarrowTab(t.key)} style={{
+            flex: 1, padding: '8px', textAlign: 'center', cursor: 'pointer',
+            background: narrowTab === t.key ? T.panelBg : 'transparent',
+            borderBottom: narrowTab === t.key ? `2px solid ${T.accent}` : '2px solid transparent',
+          }}>
+            <span style={{
+              fontFamily: FONT, fontSize: FS.body,
+              color: narrowTab === t.key ? T.accent : T.textSecondary, letterSpacing: '1px',
+            }}>{t.label}</span>
+          </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
Redesign player dashboard from centre-focused two-column layout into three-column architecture with collapsible sidebars and three responsive breakpoints (wide >=850px, medium 600-849px, narrow <600px).

- Rewrite TopBar: layout-aware rendering, remove tab switcher
- ActionPanel: fixed 240px width, compact sizing, hideCollapse prop
- New DataPanel replaces MainDashboard as collapsible right sidebar
- App.jsx: useWindowWidth hook, conditional clouds, three-mode layout
- Sub-components: body font tooltips at 12-13px (SegBar, MiniGauge, MiniAccum, ResidentChip)