### PR TITLE
Extract completion modals and info popups from App.jsx

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,6 +10,8 @@ import { RecruitModal } from './components/RecruitModal';
 import { BuildModal } from './components/BuildModal';
 import { PoliciesModal } from './components/PoliciesModal';
 import { ResearchModal } from './components/ResearchModal';
+import { CompletionModal } from './components/CompletionModal';
+import { InfoPopup } from './components/devtools/InfoPopup';
 import FortLlamaLanding from './components/FortLlamaLanding';
 
 const API_BASE = '';
@@ -2035,232 +2037,49 @@ function App({ mode = 'player' }) {
         </div>
       )}
 
-      {infoPopup && (
-        <div className="modal-overlay" onClick={() => setInfoPopup(null)}>
-          <div className="info-popup-modal" onClick={(e) => e.stopPropagation()}>
-            <button className="close-button" onClick={() => setInfoPopup(null)}>×</button>
-            {infoPopup === 'livingStandards' && (
-              <>
-                <h2>Living Standards</h2>
-                <div className="formula-section">
-                  <h4>Raw Formula</h4>
-                  <code>LS_raw = baseline(Nutrition) × damp(Cleanliness) × damp(Crowding) × damp(Maintenance)</code>
-                  <p>Nutrition provides the baseline. Cleanliness, Crowding and Maintenance are dampeners (higher debt = worse).</p>
-                </div>
-                <div className="formula-section">
-                  <h4>Scoring (0-100)</h4>
-                  <code>M_ref = ref0 × (pop/pop0)^alpha × levelMult[level]</code>
-                  <code>score = 100 × (raw/M_ref)^p / (1 + (raw/M_ref)^p)</code>
-                  <p>Score is normalized against a population-scaled reference. At raw = M_ref, score = 50. Higher p = steeper curve.</p>
-                </div>
-                <div className="formula-section">
-                  <h4>Primitives Used</h4>
-                  <ul>
-                    <li><strong>Nutrition</strong> (baseline × nutritionWeight) - Food quality from Kitchen</li>
-                    <li><strong>Cleanliness</strong> (dampener × cleanlinessDampen) - Mess debt reduces LS</li>
-                    <li><strong>Crowding</strong> (dampener × crowdingDampen) - Worst ratio across all rooms</li>
-                    <li><strong>Maintenance</strong> (dampener × maintenanceDampen) - Wear debt reduces LS</li>
-                  </ul>
-                </div>
-                <div className="formula-section">
-                  <h4>Buildings</h4>
-                  <ul>
-                    <li><strong>Kitchen</strong> - Quality & foodMult affect Nutrition throughput</li>
-                    <li><strong>Bathroom</strong> - Count, quality & cleanMult affect Cleanliness recovery</li>
-                    <li><strong>All rooms</strong> - Crowding = max ratio across Bedroom/Bathroom/Kitchen/Living Room</li>
-                    <li><strong>Utility Closet</strong> - Quality & repairMult affect Maintenance recovery</li>
-                  </ul>
-                </div>
-                <div className="formula-section">
-                  <h4>Resident Stats</h4>
-                  <ul>
-                    <li><strong>Cooking Skill</strong> - Boosts Nutrition output</li>
-                    <li><strong>Tidiness</strong> - Boosts Cleanliness recovery</li>
-                    <li><strong>Handiness</strong> - Boosts Maintenance recovery</li>
-                    <li><strong>Sharing Tolerance</strong> - Reduces effective resident count for crowding</li>
-                    <li><strong>Consideration</strong> - Helps Cleanliness recovery</li>
-                  </ul>
-                </div>
-                <div className="formula-section effect">
-                  <h4>Game Effect</h4>
-                  <p>Higher Living Standards = higher rent tolerance. At LS=35, £100 rent feels 'Fair'. At LS=100, residents tolerate up to £500.</p>
-                  <code>maxTolerantRent = rentMin + (rentMax - rentMin) × LS^(1/rentTierCurvature)</code>
-                  <p>Rent level (Bargain→Cheap→Fair→Pricey→Extortionate) depends on where current rent falls relative to maxTolerantRent.</p>
-                </div>
-              </>
-            )}
-            {infoPopup === 'productivity' && (
-              <>
-                <h2>Productivity</h2>
-                <div className="formula-section">
-                  <h4>Raw Formula</h4>
-                  <code>PR_raw = baseline(Drive) × damp(Fatigue, w_PR) × damp(Noise) × damp(Crowding)</code>
-                  <p>Drive provides the baseline. Noise and Crowding are fixed dampeners. Fatigue weight is dynamic: communes leaning toward productivity get hit harder by fatigue.</p>
-                </div>
-                <div className="formula-section">
-                  <h4>Dynamic Fatigue Weight</h4>
-                  <code>prShare = PR_preFatigue / (PR_preFatigue + PT_preFatigue)</code>
-                  <code>w_PR = baseFatigueWeight + (prShare − 0.5) × fatigueWeightSwing</code>
-                  <p>When the commune is more productive than party-oriented, fatigue dampens PR more. Configured via Base fatigue wt and Fatigue swing.</p>
-                </div>
-                <div className="formula-section">
-                  <h4>Scoring (0-100)</h4>
-                  <code>M_ref = ref0 × (pop/pop0)^alpha × levelMult[level]</code>
-                  <code>score = 100 × (raw/M_ref)^p / (1 + (raw/M_ref)^p)</code>
-                  <p>Score is normalized against a population-scaled reference. At raw = M_ref, score = 50. Higher p = steeper curve.</p>
-                </div>
-                <div className="formula-section">
-                  <h4>Primitives Used</h4>
-                  <ul>
-                    <li><strong>Drive</strong> (baseline × driveWeight) - Motivation from workspace</li>
-                    <li><strong>Fatigue</strong> (dampener, dynamic weight) - Tiredness reduces output; weight shifts with commune balance</li>
-                    <li><strong>Noise</strong> (dampener × noiseWeight) - Distractions reduce focus</li>
-                    <li><strong>Crowding</strong> (dampener × crowdingWeight) - Overcrowding hurts focus</li>
-                  </ul>
-                </div>
-                <div className="formula-section">
-                  <h4>Buildings</h4>
-                  <ul>
-                    <li><strong>Living Room</strong> - Quality affects Drive; capacity affects distractions</li>
-                    <li><strong>Bedroom</strong> - Quality & recoveryMult affect Fatigue recovery</li>
-                  </ul>
-                </div>
-                <div className="formula-section">
-                  <h4>Resident Stats</h4>
-                  <ul>
-                    <li><strong>Work Ethic</strong> - Directly boosts Drive</li>
-                    <li><strong>Consideration</strong> - Reduces noise and distractions</li>
-                    <li><strong>Party Stamina</strong> - Improves Fatigue recovery</li>
-                    <li><strong>Sociability</strong> - Increases noise/distractions (negative here!)</li>
-                  </ul>
-                </div>
-                <div className="formula-section effect">
-                  <h4>Game Effect</h4>
-                  <p>At PR=35, churn is neutral. Above 35, churn decreases by 1% per point. Below 35, churn increases. Productive communes keep residents longer even at higher rents.</p>
-                </div>
-              </>
-            )}
-            {infoPopup === 'partytime' && (
-              <>
-                <h2>Leisure</h2>
-                <div className="formula-section">
-                  <h4>Raw Formula</h4>
-                  <code>PT_raw = baseline(Fun) × damp(Fatigue, w_PT)</code>
-                  <p>Fun provides the baseline. Fatigue is the only dampener. Fatigue weight is dynamic: party-oriented communes get hit harder by fatigue.</p>
-                </div>
-                <div className="formula-section">
-                  <h4>Scoring (0-100)</h4>
-                  <code>M_ref = ref0 × (pop/pop0)^alpha × levelMult[level]</code>
-                  <code>score = 100 × (raw/M_ref)^p / (1 + (raw/M_ref)^p)</code>
-                  <p>Score is normalized against a population-scaled reference. At raw = M_ref, score = 50. Higher p = steeper curve.</p>
-                </div>
-                <div className="formula-section">
-                  <h4>Primitives Used</h4>
-                  <ul>
-                    <li><strong>Fun</strong> (baseline × funWeight) - Party energy from social activity</li>
-                    <li><strong>Fatigue</strong> (dampener, dynamic weight) - Too tired to party; weight shifts with commune balance</li>
-                  </ul>
-                </div>
-                <div className="formula-section">
-                  <h4>Buildings</h4>
-                  <ul>
-                    <li><strong>Living Room</strong> - Quality & funMult directly affect Fun; capacity affects crowd factor</li>
-                    <li><strong>Bedroom</strong> - Quality & recoveryMult affect Fatigue recovery</li>
-                  </ul>
-                </div>
-                <div className="formula-section">
-                  <h4>Resident Stats</h4>
-                  <ul>
-                    <li><strong>Sociability</strong> - Boosts Fun</li>
-                    <li><strong>Party Stamina</strong> - Boosts Fun and Fatigue recovery</li>
-                    <li><strong>Consideration</strong> - No impact on Leisure</li>
-                  </ul>
-                </div>
-                <div className="formula-section effect">
-                  <h4>Game Effect</h4>
-                  <p>At PT=35, you get base recruitment slots. Every +15 PT adds +1 extra slot. A fun commune attracts more potential residents.</p>
-                </div>
-              </>
-            )}
-          </div>
-        </div>
-      )}
+      {infoPopup && <InfoPopup popup={infoPopup} onClose={() => setInfoPopup(null)} />}
 
       {buildComplete && (
-        <div className="modal-overlay" onClick={() => setBuildComplete(null)}>
-          <div className="modal" onClick={(e) => e.stopPropagation()} style={{maxWidth: '360px', textAlign: 'center'}}>
-            <div style={{fontSize: '2rem', marginBottom: '8px'}}>&#127959;</div>
-            <h2 style={{color: T.positive}}>Building Complete</h2>
-            <p style={{color: T.textPrimary, fontSize: '0.9rem', margin: '12px 0'}}>
-              New <span style={{fontWeight: 600}}>{buildComplete.name}</span> built successfully.
-            </p>
-            <div style={{background: T.bg, borderRadius: '8px', padding: '12px', marginBottom: '16px'}}>
-              <div style={{display: 'flex', justifyContent: 'space-between', marginBottom: '6px'}}>
-                <span style={{color: T.textSecondary}}>Total {buildComplete.name}</span>
-                <span style={{color: T.textPrimary}}>{buildComplete.count}</span>
-              </div>
-              <div style={{display: 'flex', justifyContent: 'space-between', marginBottom: '6px'}}>
-                <span style={{color: T.textSecondary}}>Cost</span>
-                <span style={{color: T.negative}}>-£{buildComplete.cost?.toLocaleString()}</span>
-              </div>
-              <div style={{display: 'flex', justifyContent: 'space-between'}}>
-                <span style={{color: T.textSecondary}}>Total Capacity</span>
-                <span style={{color: T.positive}}>{buildComplete.capacity}</span>
-              </div>
-            </div>
-            <button className="action-button" onClick={() => setBuildComplete(null)}>
-              Done
-            </button>
-          </div>
-        </div>
+        <CompletionModal
+          icon={'\u{1F3D7}'}
+          title="Building Complete"
+          titleColor={T.positive}
+          message={<>New <span style={{fontWeight: 600}}>{buildComplete.name}</span> built successfully.</>}
+          rows={[
+            { label: `Total ${buildComplete.name}`, value: buildComplete.count },
+            { label: 'Cost', value: `-£${buildComplete.cost?.toLocaleString()}`, color: T.negative },
+            { label: 'Total Capacity', value: buildComplete.capacity, color: T.positive },
+          ]}
+          onClose={() => setBuildComplete(null)}
+        />
       )}
 
       {policyComplete && (
-        <div className="modal-overlay" onClick={() => setPolicyComplete(null)}>
-          <div className="modal" onClick={(e) => e.stopPropagation()} style={{maxWidth: '360px', textAlign: 'center'}}>
-            <div style={{fontSize: '2rem', marginBottom: '8px'}}>{policyComplete.action === 'activated' ? '\u2705' : '\u274C'}</div>
-            <h2 style={{color: policyComplete.action === 'activated' ? T.positive : T.negative}}>
-              Policy {policyComplete.action === 'activated' ? 'Activated' : 'Deactivated'}
-            </h2>
-            <p style={{color: T.textPrimary, fontSize: '0.9rem', margin: '12px 0'}}>
-              <span style={{fontWeight: 600}}>{policyComplete.name}</span> has been {policyComplete.action}.
-            </p>
-            <div style={{background: T.bg, borderRadius: '8px', padding: '12px', marginBottom: '16px', textAlign: 'left'}}>
-              <div style={{display: 'flex', justifyContent: 'space-between'}}>
-                <span style={{color: T.textSecondary}}>Affects</span>
-                <span style={{color: T.textPrimary, textTransform: 'capitalize'}}>{policyComplete.primitive}</span>
-              </div>
-            </div>
-            <button className="action-button" onClick={() => setPolicyComplete(null)}>
-              Done
-            </button>
-          </div>
-        </div>
+        <CompletionModal
+          icon={policyComplete.action === 'activated' ? '\u2705' : '\u274C'}
+          title={`Policy ${policyComplete.action === 'activated' ? 'Activated' : 'Deactivated'}`}
+          titleColor={policyComplete.action === 'activated' ? T.positive : T.negative}
+          message={<><span style={{fontWeight: 600}}>{policyComplete.name}</span> has been {policyComplete.action}.</>}
+          rows={[
+            { label: 'Affects', value: policyComplete.primitive, style: { textTransform: 'capitalize' } },
+          ]}
+          onClose={() => setPolicyComplete(null)}
+        />
       )}
 
       {techComplete && (
-        <div className="modal-overlay" onClick={() => setTechComplete(null)}>
-          <div className="modal" onClick={(e) => e.stopPropagation()} style={{maxWidth: '380px', textAlign: 'center'}}>
-            <div style={{fontSize: '2rem', marginBottom: '8px'}}>&#128300;</div>
-            <h2 style={{color: T.positive}}>Research Complete</h2>
-            <p style={{color: T.textPrimary, fontSize: '0.9rem', margin: '12px 0'}}>
-              <span style={{fontWeight: 600}}>{techComplete.name}</span> has been researched.
-            </p>
-            <div style={{background: T.bg, borderRadius: '8px', padding: '12px', marginBottom: '16px', textAlign: 'left'}}>
-              <div style={{display: 'flex', justifyContent: 'space-between', marginBottom: '6px'}}>
-                <span style={{color: T.textSecondary}}>Type</span>
-                <span style={{color: T.textPrimary, textTransform: 'capitalize'}}>{techComplete.type?.replace('_', ' ')}</span>
-              </div>
-              <div style={{display: 'flex', justifyContent: 'space-between'}}>
-                <span style={{color: T.textSecondary}}>Tree</span>
-                <span style={{color: T.textPrimary}}>{TREE_LABELS[techComplete.tree] || techComplete.tree}</span>
-              </div>
-            </div>
-            <button className="action-button" onClick={() => setTechComplete(null)}>
-              Done
-            </button>
-          </div>
-        </div>
+        <CompletionModal
+          icon={'\u{1F52C}'}
+          title="Research Complete"
+          titleColor={T.positive}
+          maxWidth="380px"
+          message={<><span style={{fontWeight: 600}}>{techComplete.name}</span> has been researched.</>}
+          rows={[
+            { label: 'Type', value: techComplete.type?.replace('_', ' '), style: { textTransform: 'capitalize' } },
+            { label: 'Tree', value: TREE_LABELS[techComplete.tree] || techComplete.tree },
+          ]}
+          onClose={() => setTechComplete(null)}
+        />
       )}
 
       {showLlamaPoolEditor && (

--- a/client/src/components/CompletionModal.jsx
+++ b/client/src/components/CompletionModal.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { T } from './theme';
+
+// Centered "action complete" toast modal: icon, coloured title, message, detail rows.
+// Used for build/policy/research completion confirmations.
+export function CompletionModal({ icon, title, titleColor, message, rows, maxWidth = '360px', onClose }) {
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()} style={{ maxWidth, textAlign: 'center' }}>
+        <div style={{ fontSize: '2rem', marginBottom: '8px' }}>{icon}</div>
+        <h2 style={{ color: titleColor }}>{title}</h2>
+        <p style={{ color: T.textPrimary, fontSize: '0.9rem', margin: '12px 0' }}>
+          {message}
+        </p>
+        <div style={{ background: T.bg, borderRadius: '8px', padding: '12px', marginBottom: '16px', textAlign: 'left' }}>
+          {rows.map((row, i) => (
+            <div key={i} style={{ display: 'flex', justifyContent: 'space-between', marginBottom: i < rows.length - 1 ? '6px' : 0 }}>
+              <span style={{ color: T.textSecondary }}>{row.label}</span>
+              <span style={{ color: row.color || T.textPrimary, ...(row.style || {}) }}>{row.value}</span>
+            </div>
+          ))}
+        </div>
+        <button className="action-button" onClick={onClose}>
+          Done
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/devtools/InfoPopup.jsx
+++ b/client/src/components/devtools/InfoPopup.jsx
@@ -1,0 +1,163 @@
+import React from 'react';
+
+// Formula-explanation popups for the health metrics, opened from the dev tools
+// panel's info icons. Content is keyed by popup id; add new popups to the map.
+
+const POPUP_CONTENT = {
+  livingStandards: (
+    <>
+      <h2>Living Standards</h2>
+      <div className="formula-section">
+        <h4>Raw Formula</h4>
+        <code>LS_raw = baseline(Nutrition) × damp(Cleanliness) × damp(Crowding) × damp(Maintenance)</code>
+        <p>Nutrition provides the baseline. Cleanliness, Crowding and Maintenance are dampeners (higher debt = worse).</p>
+      </div>
+      <div className="formula-section">
+        <h4>Scoring (0-100)</h4>
+        <code>M_ref = ref0 × (pop/pop0)^alpha × levelMult[level]</code>
+        <code>score = 100 × (raw/M_ref)^p / (1 + (raw/M_ref)^p)</code>
+        <p>Score is normalized against a population-scaled reference. At raw = M_ref, score = 50. Higher p = steeper curve.</p>
+      </div>
+      <div className="formula-section">
+        <h4>Primitives Used</h4>
+        <ul>
+          <li><strong>Nutrition</strong> (baseline × nutritionWeight) - Food quality from Kitchen</li>
+          <li><strong>Cleanliness</strong> (dampener × cleanlinessDampen) - Mess debt reduces LS</li>
+          <li><strong>Crowding</strong> (dampener × crowdingDampen) - Worst ratio across all rooms</li>
+          <li><strong>Maintenance</strong> (dampener × maintenanceDampen) - Wear debt reduces LS</li>
+        </ul>
+      </div>
+      <div className="formula-section">
+        <h4>Buildings</h4>
+        <ul>
+          <li><strong>Kitchen</strong> - Quality &amp; foodMult affect Nutrition throughput</li>
+          <li><strong>Bathroom</strong> - Count, quality &amp; cleanMult affect Cleanliness recovery</li>
+          <li><strong>All rooms</strong> - Crowding = max ratio across Bedroom/Bathroom/Kitchen/Living Room</li>
+          <li><strong>Utility Closet</strong> - Quality &amp; repairMult affect Maintenance recovery</li>
+        </ul>
+      </div>
+      <div className="formula-section">
+        <h4>Resident Stats</h4>
+        <ul>
+          <li><strong>Cooking Skill</strong> - Boosts Nutrition output</li>
+          <li><strong>Tidiness</strong> - Boosts Cleanliness recovery</li>
+          <li><strong>Handiness</strong> - Boosts Maintenance recovery</li>
+          <li><strong>Sharing Tolerance</strong> - Reduces effective resident count for crowding</li>
+          <li><strong>Consideration</strong> - Helps Cleanliness recovery</li>
+        </ul>
+      </div>
+      <div className="formula-section effect">
+        <h4>Game Effect</h4>
+        <p>Higher Living Standards = higher rent tolerance. At LS=35, £100 rent feels 'Fair'. At LS=100, residents tolerate up to £500.</p>
+        <code>maxTolerantRent = rentMin + (rentMax - rentMin) × LS^(1/rentTierCurvature)</code>
+        <p>Rent level (Bargain→Cheap→Fair→Pricey→Extortionate) depends on where current rent falls relative to maxTolerantRent.</p>
+      </div>
+    </>
+  ),
+  productivity: (
+    <>
+      <h2>Productivity</h2>
+      <div className="formula-section">
+        <h4>Raw Formula</h4>
+        <code>PR_raw = baseline(Drive) × damp(Fatigue, w_PR) × damp(Noise) × damp(Crowding)</code>
+        <p>Drive provides the baseline. Noise and Crowding are fixed dampeners. Fatigue weight is dynamic: communes leaning toward productivity get hit harder by fatigue.</p>
+      </div>
+      <div className="formula-section">
+        <h4>Dynamic Fatigue Weight</h4>
+        <code>prShare = PR_preFatigue / (PR_preFatigue + PT_preFatigue)</code>
+        <code>w_PR = baseFatigueWeight + (prShare − 0.5) × fatigueWeightSwing</code>
+        <p>When the commune is more productive than party-oriented, fatigue dampens PR more. Configured via Base fatigue wt and Fatigue swing.</p>
+      </div>
+      <div className="formula-section">
+        <h4>Scoring (0-100)</h4>
+        <code>M_ref = ref0 × (pop/pop0)^alpha × levelMult[level]</code>
+        <code>score = 100 × (raw/M_ref)^p / (1 + (raw/M_ref)^p)</code>
+        <p>Score is normalized against a population-scaled reference. At raw = M_ref, score = 50. Higher p = steeper curve.</p>
+      </div>
+      <div className="formula-section">
+        <h4>Primitives Used</h4>
+        <ul>
+          <li><strong>Drive</strong> (baseline × driveWeight) - Motivation from workspace</li>
+          <li><strong>Fatigue</strong> (dampener, dynamic weight) - Tiredness reduces output; weight shifts with commune balance</li>
+          <li><strong>Noise</strong> (dampener × noiseWeight) - Distractions reduce focus</li>
+          <li><strong>Crowding</strong> (dampener × crowdingWeight) - Overcrowding hurts focus</li>
+        </ul>
+      </div>
+      <div className="formula-section">
+        <h4>Buildings</h4>
+        <ul>
+          <li><strong>Living Room</strong> - Quality affects Drive; capacity affects distractions</li>
+          <li><strong>Bedroom</strong> - Quality &amp; recoveryMult affect Fatigue recovery</li>
+        </ul>
+      </div>
+      <div className="formula-section">
+        <h4>Resident Stats</h4>
+        <ul>
+          <li><strong>Work Ethic</strong> - Directly boosts Drive</li>
+          <li><strong>Consideration</strong> - Reduces noise and distractions</li>
+          <li><strong>Party Stamina</strong> - Improves Fatigue recovery</li>
+          <li><strong>Sociability</strong> - Increases noise/distractions (negative here!)</li>
+        </ul>
+      </div>
+      <div className="formula-section effect">
+        <h4>Game Effect</h4>
+        <p>At PR=35, churn is neutral. Above 35, churn decreases by 1% per point. Below 35, churn increases. Productive communes keep residents longer even at higher rents.</p>
+      </div>
+    </>
+  ),
+  partytime: (
+    <>
+      <h2>Leisure</h2>
+      <div className="formula-section">
+        <h4>Raw Formula</h4>
+        <code>PT_raw = baseline(Fun) × damp(Fatigue, w_PT)</code>
+        <p>Fun provides the baseline. Fatigue is the only dampener. Fatigue weight is dynamic: party-oriented communes get hit harder by fatigue.</p>
+      </div>
+      <div className="formula-section">
+        <h4>Scoring (0-100)</h4>
+        <code>M_ref = ref0 × (pop/pop0)^alpha × levelMult[level]</code>
+        <code>score = 100 × (raw/M_ref)^p / (1 + (raw/M_ref)^p)</code>
+        <p>Score is normalized against a population-scaled reference. At raw = M_ref, score = 50. Higher p = steeper curve.</p>
+      </div>
+      <div className="formula-section">
+        <h4>Primitives Used</h4>
+        <ul>
+          <li><strong>Fun</strong> (baseline × funWeight) - Party energy from social activity</li>
+          <li><strong>Fatigue</strong> (dampener, dynamic weight) - Too tired to party; weight shifts with commune balance</li>
+        </ul>
+      </div>
+      <div className="formula-section">
+        <h4>Buildings</h4>
+        <ul>
+          <li><strong>Living Room</strong> - Quality &amp; funMult directly affect Fun; capacity affects crowd factor</li>
+          <li><strong>Bedroom</strong> - Quality &amp; recoveryMult affect Fatigue recovery</li>
+        </ul>
+      </div>
+      <div className="formula-section">
+        <h4>Resident Stats</h4>
+        <ul>
+          <li><strong>Sociability</strong> - Boosts Fun</li>
+          <li><strong>Party Stamina</strong> - Boosts Fun and Fatigue recovery</li>
+          <li><strong>Consideration</strong> - No impact on Leisure</li>
+        </ul>
+      </div>
+      <div className="formula-section effect">
+        <h4>Game Effect</h4>
+        <p>At PT=35, you get base recruitment slots. Every +15 PT adds +1 extra slot. A fun commune attracts more potential residents.</p>
+      </div>
+    </>
+  ),
+};
+
+export function InfoPopup({ popup, onClose }) {
+  const content = POPUP_CONTENT[popup];
+  if (!content) return null;
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="info-popup-modal" onClick={(e) => e.stopPropagation()}>
+        <button className="close-button" onClick={onClose}>×</button>
+        {content}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New shared `CompletionModal.jsx` replaces the three inline build/policy/research completion toasts
- New `components/devtools/InfoPopup.jsx` (first file of the devtools subtree) replaces the inline LS/PR/PT formula popup chain with a content map
- App.jsx: 2,600 → 2,419 lines; behaviour and styling preserved

## Test plan
- `npm run build` passes
- Visual: trigger a build/policy/research completion and each dev-panel ⓘ popup

Depends on #25 (stacked — merge #25 first; GitHub will retarget this PR to main)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)